### PR TITLE
[ENH] Add `predictably` level configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,11 @@ repos:
       - id: mypy
         files: predictably/
         args: [--strict, --ignore-missing-imports]
+        exclude: |
+          (?x)(
+              /tests/|
+              docs/source
+          )
         additional_dependencies: []
 
   - repo: https://github.com/pycqa/pydocstyle
@@ -121,3 +126,8 @@ repos:
     rev: 41a1508
     hooks:
       - id: numpydoc-validation
+        exclude: |
+          (?x)(
+              /tests/|
+              docs/source
+          )

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -282,7 +282,7 @@ numpydoc_show_class_members = True
 numpydoc_class_members_toctree = False
 
 numpydoc_validation_checks = {"all", "GL01", "SA01"}
-numpydoc_validation_exclude = [r"\.__init__$"]
+numpydoc_validation_exclude = [r".\\tests\\.*", r"\.__init__$"]
 
 # -- Options for sphinx-copybutton extension----------------------------------
 copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "

--- a/predictably/__init__.py
+++ b/predictably/__init__.py
@@ -6,7 +6,21 @@ Predictable, well-documented interfaces so you can predict *ably*.
 """
 from typing import List
 
+from predictably._config import (
+    config_context,
+    get_config,
+    get_default_config,
+    reset_config,
+    set_config,
+)
+
 __version__: str = "0.2.0"
 
 __author__: List[str] = ["RNKuhns"]
-__all__: List[str] = []
+__all__: List[str] = [
+    "get_default_config",
+    "get_config",
+    "set_config",
+    "reset_config",
+    "config_context",
+]

--- a/predictably/_config.py
+++ b/predictably/_config.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3 -u
+# copyright: predict-ably, BSD-3-Clause License (see LICENSE file)
+# Includes functionality like get_config, set_config, and config_context
+# that is similar to scikit-learn and skbase. These elements are copyrighted by
+# their respective developers. For conditions see
+# https://github.com/scikit-learn/scikit-learn/blob/main/COPYING
+# https://github.com/sktime/skbase/blob/main/LICENSE
+"""Implement logic for global configuration of predictably.
+
+Allows users to configure `predictably`.
+"""
+import threading
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Literal, Optional, get_args
+
+from predictably._config_param_setting import GlobalConfigParamSetting
+
+__author__: List[str] = ["RNKuhns"]
+__all__: List[str] = [
+    "get_default_config",
+    "get_config",
+    "set_config",
+    "reset_config",
+    "config_context",
+]
+
+
+GlobalConfigParam = str
+DATAFRAME_BACKENDS = Literal["polars", "pandas", "fugue", "input"]
+MATH_BACKENDS = Literal["predictably", "numba", "numpy"]
+df_backend_values = get_args(DATAFRAME_BACKENDS)
+math_backend_values = get_args(MATH_BACKENDS)
+
+_CONFIG_REGISTRY: Dict[GlobalConfigParam, GlobalConfigParamSetting] = {
+    "dataframe_backend": GlobalConfigParamSetting(
+        name="dataframe_backend",
+        expected_type=str,
+        allowed_values=df_backend_values,
+        default_value="polars",
+    ),
+    "math_backend": GlobalConfigParamSetting(
+        name="math_backend",
+        expected_type=str,
+        allowed_values=math_backend_values,
+        default_value="predictably",
+    ),
+    "print_changed_only": GlobalConfigParamSetting(
+        name="print_changed_only",
+        expected_type=bool,
+        allowed_values=(True, False),
+        default_value=True,
+    ),
+    "display": GlobalConfigParamSetting(
+        name="display",
+        expected_type=str,
+        allowed_values=("text", "diagram"),
+        default_value="text",
+    ),
+}
+
+_GLOBAL_CONFIG_DEFAULT: Dict[GlobalConfigParam, Any] = {
+    config_settings.name: config_settings.default_value
+    for _, config_settings in _CONFIG_REGISTRY.items()
+}
+
+global_config = _GLOBAL_CONFIG_DEFAULT.copy()
+
+_THREAD_LOCAL_DATA = threading.local()
+
+
+def _get_threadlocal_config() -> Dict[GlobalConfigParam, Any]:
+    """Get a threadlocal **mutable** configuration.
+
+    If the configuration does not exist, copy the default global configuration.
+
+    Returns
+    -------
+    dict
+        Threadlocal global config or copy of default global configuration.
+    """
+    if not hasattr(_THREAD_LOCAL_DATA, "global_config"):
+        _THREAD_LOCAL_DATA.global_config = global_config.copy()
+    return _THREAD_LOCAL_DATA.global_config  # type: ignore
+
+
+def get_default_config() -> Dict[GlobalConfigParam, Any]:
+    """Retrieve the default global configuration.
+
+    This will always return the default ``predictably`` global configuration.
+
+    Returns
+    -------
+    dict
+        The default configurable settings (keys) and their default values (values).
+
+    See Also
+    --------
+    config_context :
+        Configuration context manager.
+    get_config :
+        Retrieve current global configuration values.
+    set_config :
+        Set global configuration.
+    reset_config :
+        Reset configuration to ``predictably`` default.
+
+    Examples
+    --------
+    >>> from predictably import get_default_config
+    >>> get_default_config()  # doctest: +ELLIPSIS
+    {'dataframe_backend': 'polars', ..., 'display': 'text'}
+    """
+    return _GLOBAL_CONFIG_DEFAULT.copy()
+
+
+def get_config() -> Dict[GlobalConfigParam, Any]:
+    """Retrieve current values for configuration set by :meth:`set_config`.
+
+    Will return the default configuration if know updated configuration has
+    been set by :meth:`set_config`.
+
+    Returns
+    -------
+    dict
+        The configurable settings (keys) and their default values (values).
+
+    See Also
+    --------
+    config_context :
+        Configuration context manager.
+    get_default_config :
+        Retrieve ``predictably``'s default configuration.
+    set_config :
+        Set global configuration.
+    reset_config :
+        Reset configuration to ``predictably`` default.
+
+    Examples
+    --------
+    >>> from predictably import get_config
+    >>> get_config()  # doctest: +ELLIPSIS
+    {'dataframe_backend': 'polars', ..., 'display': 'text'}
+    """
+    return _get_threadlocal_config().copy()
+
+
+def set_config(
+    *,
+    dataframe_backend: Optional[DATAFRAME_BACKENDS] = None,
+    math_backend: Optional[MATH_BACKENDS] = None,
+    print_changed_only: Optional[bool] = None,
+    display: Optional[Literal["text", "diagram"]] = None,
+    local_threadsafe: bool = False,
+) -> None:
+    """Set global configuration.
+
+    Allows the ``predictably`` global configuration to be updated.
+
+    Parameters
+    ----------
+    dataframe_backend : {"polars", "pandas", "fugue", "input"}, default=None
+        The dataframe backend to use internally in `predictably`.
+
+        - If "polars", "pandas", or "fugue" then input data will be converted to
+          the specified type as necessary.
+        - If "input" then the dataframe will be processed using the type of its
+          input. For example, if the input is a `polars.DataFrame` or
+          `polars.LazyFrame` it will be processed as a `polars.LazyFrame`.
+
+    math_backend : {"predictably", "numba", "numpy"}, default=None
+        The backend to use for mathematical processing.
+
+        - If "predictably" than predictably's internal methods, including pre-compiled
+          `Rust` code.
+        - If "numba" or "numpy" then math and linear algebra processing will use
+          `numba` or `numpy`, respectively.
+
+    print_changed_only : bool, default=None
+        If True, only the parameters that were set to non-default
+        values will be printed when printing a BaseObject instance. For example,
+        ``print(SVC())`` while True will only print 'SVC()', but would print
+        'SVC(C=1.0, cache_size=200, ...)' with all the non-changed parameters
+        when False. If None, the existing value won't change.
+    display : {'text', 'diagram'}, default=None
+        If 'diagram', instances inheritting from BaseOBject will be displayed
+        as a diagram in a Jupyter lab or notebook context. If 'text', instances
+        inheritting from BaseObject will be displayed as text. If None, the
+        existing value won't change.
+    local_threadsafe : bool, default=False
+        If False, set the backend as default for all threads.
+
+    Returns
+    -------
+    None
+        No output returned.
+
+    See Also
+    --------
+    config_context :
+        Configuration context manager.
+    get_default_config :
+        Retrieve ``predictably``'s default configuration.
+    get_config :
+        Retrieve current global configuration values.
+    reset_config :
+        Reset configuration to default.
+
+    Examples
+    --------
+    >>> from predictably import get_config, set_config
+    >>> get_config()  # doctest: +ELLIPSIS
+    {'dataframe_backend': 'polars', ..., 'display': 'text'}
+    >>> set_config(display='diagram')
+    >>> get_config()  # doctest: +ELLIPSIS
+    {'dataframe_backend': 'polars', ..., 'display': 'diagram'}
+    """
+    local_config = _get_threadlocal_config()
+    msg = "Attempting to set an invalid value for a global configuration.\n"
+    msg += "Using current configuration value of parameter as a result.\n"
+
+    def _update_local_config(
+        local_config: Dict[GlobalConfigParam, Any],
+        param: Any,
+        param_name: str,
+        msg: str,
+    ) -> Dict[GlobalConfigParam, Any]:
+        """Update a local config with a parameter value.
+
+        Utility function used to update the local config dictionary.
+
+        Parameters
+        ----------
+        local_config : dict[GlobalConfigParam, Any]
+            The local configuration to update.
+        param : Any
+            The parameter value to update.
+        param_name : str
+            The name of the parameter to update.
+        msg : str
+            Message to pass to `GlobalConfigParam.get_valid_param_or_default`.
+
+        Returns
+        -------
+        dict
+            The updated local configuration.
+        """
+        config_reg = _CONFIG_REGISTRY.copy()
+        value = config_reg[param_name].get_valid_param_or_default(
+            param,
+            default_value=local_config[param_name],
+            msg=msg,
+        )
+        local_config[param_name] = value
+        return local_config
+
+    if dataframe_backend is not None:
+        local_config = _update_local_config(
+            local_config, dataframe_backend, "dataframe_backend", msg
+        )
+    if math_backend is not None:
+        local_config = _update_local_config(
+            local_config, math_backend, "math_backend", msg
+        )
+    if print_changed_only is not None:
+        local_config = _update_local_config(
+            local_config, print_changed_only, "print_changed_only", msg
+        )
+    if display is not None:
+        local_config = _update_local_config(local_config, display, "display", msg)
+
+    if not local_threadsafe:
+        global_config.update(local_config)
+
+    return None
+
+
+def reset_config() -> None:
+    """Reset the global configuration to the default.
+
+    Will remove any user updates to the global configuration and reset the values
+    back to the ``predictably`` defaults.
+
+    Returns
+    -------
+    None
+        No output returned.
+
+    See Also
+    --------
+    config_context :
+        Configuration context manager.
+    get_default_config :
+        Retrieve ``predictably``'s default configuration.
+    get_config :
+        Retrieve current global configuration values.
+    set_config :
+        Set global configuration.
+
+    Examples
+    --------
+    >>> from predictably import get_config, set_config, reset_config
+    >>> get_config()  # doctest: +ELLIPSIS
+    {'dataframe_backend': 'polars', ..., 'display': 'text'}
+    >>> set_config(display='diagram')
+    >>> get_config()  # doctest: +ELLIPSIS
+    {'dataframe_backend': 'polars', ..., 'display': 'diagram'}
+    >>> get_config() == get_default_config()
+    False
+    >>> reset_config()
+    >>> get_config()  # doctest: +ELLIPSIS
+    {'dataframe_backend': 'polars', ..., 'display': 'text'}
+    >>> get_config() == get_default_config()
+    True
+    """
+    default_config = get_default_config()
+    set_config(**default_config)
+    return None
+
+
+@contextmanager
+def config_context(
+    *,
+    dataframe_backend: Optional[DATAFRAME_BACKENDS] = None,
+    math_backend: Optional[MATH_BACKENDS] = None,
+    print_changed_only: Optional[bool] = None,
+    display: Optional[Literal["text", "diagram"]] = None,
+    local_threadsafe: bool = False,
+) -> Iterator[None]:
+    """Context manager for global configuration.
+
+    Provides the ability to run code using different configuration without
+    having to update the global config.
+
+    Parameters
+    ----------
+    dataframe_backend : {"polars", "pandas", "fugue", "input"}, default=None
+        The dataframe backend to use internally in `predictably`.
+
+        - If "polars", "pandas", or "fugue" then input data will be converted to
+          the specified type as necessary.
+        - If "input" then the dataframe will be processed using the type of its
+          input. For example, if the input is a `polars.DataFrame` or
+          `polars.LazyFrame` it will be processed as a `polars.LazyFrame`.
+
+    math_backend : {"predictably", "numba", "numpy"}, default=None
+        The backend to use for mathematical processing.
+
+        - If "predictably" than predictably's internal methods, including pre-compiled
+          `Rust` code.
+        - If "numba" or "numpy" then math and linear algebra processing will use
+          `numba` or `numpy`, respectively.
+
+    print_changed_only : bool, default=None
+        If True, only the parameters that were set to non-default
+        values will be printed when printing a Model instance. For example,
+        ``print(Model())`` while True will only print 'Model()', but would print
+        'Model(C=1.0, cache_size=200, ...)' with all the unchanged parameters
+        when False. If None, the existing value won't change.
+    display : {'text', 'diagram'}, default=None
+        If 'diagram', instances inheritting from BaseOBject will be displayed
+        as a diagram in a Jupyter lab or notebook context. If 'text', instances
+        inheritting from BaseObject will be displayed as text. If None, the
+        existing value won't change.
+    local_threadsafe : bool, default=False
+        If False, set the config as default for all threads.
+
+    Yields
+    ------
+    None
+        No output returned.
+
+    See Also
+    --------
+    get_default_config :
+        Retrieve ``predictably``'s default configuration.
+    get_config :
+        Retrieve current values of the global configuration.
+    set_config :
+        Set global configuration.
+    reset_config :
+        Reset configuration to ``predictably`` default.
+
+    Notes
+    -----
+    All settings, not just those presently modified, will be returned to
+    their previous values when the context manager is exited.
+
+    Examples
+    --------
+    >>> from predictably import config_context
+    >>> with config_context(display='diagram'):
+    ...     pass
+    """
+    old_config = get_config()
+    set_config(
+        dataframe_backend=dataframe_backend,
+        math_backend=math_backend,
+        print_changed_only=print_changed_only,
+        display=display,
+        local_threadsafe=local_threadsafe,
+    )
+
+    try:
+        yield
+    finally:
+        set_config(**old_config)

--- a/predictably/_config_param_setting.py
+++ b/predictably/_config_param_setting.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3 -u
+# copyright: predict-ably, BSD-3-Clause License (see LICENSE file)
+"""Class to hold information on a configurable parameter settings.
+
+Used to store information about predictably's global configuration.
+"""
+import collections
+import warnings
+from dataclasses import dataclass
+from typing import Any, List, Optional, Tuple, Union
+
+from predictably.utils._iter import _format_seq_to_str
+
+__author__: List[str] = ["RNKuhns"]
+__all__: List[str] = ["GlobalConfigParamSetting"]
+
+
+@dataclass
+class GlobalConfigParamSetting:
+    """Metadata about a given for a given config parameter.
+
+    Also provides utility methods to retrieve information about the global
+    parameter.
+    """
+
+    name: str
+    expected_type: Union[type, Tuple[type]]
+    default_value: Any
+    allowed_values: Optional[Union[Tuple[Any, ...], List[Any]]]
+
+    def _get_values(self, param: str) -> Tuple[Any, ...]:
+        """Get values of specified parameter.
+
+        Utility function to retrieve the values assigned to the specified parameter
+        as a tuple.
+
+        Parameters
+        ----------
+        param : str
+            The name of the parameter whose values should be retrieved.
+
+        Returns
+        -------
+        tuple
+            Values assigned to `param`.
+        """
+        param_values = getattr(self, param)
+        if param_values is None:
+            return ()
+        elif isinstance(param_values, collections.abc.Iterable) and not isinstance(
+            self.allowed_values, str
+        ):
+            return tuple(param_values)
+        else:
+            return (param_values,)
+
+    def get_allowed_values(self) -> Tuple[Any, ...]:
+        """Get global parameter's `allowed_values`.
+
+        Returns an empty tuple if `allowed_values` is None.
+
+        Returns
+        -------
+        tuple
+            Allowable values if any.
+        """
+        return self._get_values("allowed_values")
+
+    def get_expected_type(self) -> Tuple[type, ...]:
+        """Get global parameter's `expected_type`.
+
+        Returns an empty tuple if `expected_type` is None.
+
+        Returns
+        -------
+        tuple
+            Allowable values if any.
+        """
+        return self._get_values("expected_type")
+
+    def is_valid_param_value(self, value: Any) -> bool:
+        """Validate that a global configuration value is valid.
+
+        Verifies that the value set for a global configuration parameter is valid
+        based on the its configuration settings.
+
+        Parameters
+        ----------
+        value : Any
+            The value that is validated against the parameter's allowed_values.
+
+        Returns
+        -------
+        bool
+            Whether a parameter value is valid.
+        """
+        valid_param: bool
+        if not isinstance(value, self.expected_type):
+            valid_param = False
+        elif self.allowed_values is not None and value not in self.get_allowed_values():
+            valid_param = False
+        else:
+            valid_param = True
+        return valid_param
+
+    def get_valid_param_or_default(
+        self, value: Any, default_value: Any = None, msg: str = ""
+    ) -> Any:
+        """Retrieve validated `value` for global parameter.
+
+        Returns default if it is not valid.
+
+        Parameters
+        ----------
+        value : Any
+            The configuration parameter value to set.
+        default_value : Any, default=None
+            An optional default value to use to set the configuration parameter
+            if `value` is not valid based on defined expected type and allowed
+            values. If None, and `value` is invalid then the classes `default_value`
+            parameter is used.
+        msg : str, default=""
+            An optional message to be used as start of the UserWarning message.
+
+        Returns
+        -------
+        Any
+            The value of the parameter to be retrieved. A default value is used
+            if the provided value is invalid for the parameter.
+        """
+        if self.is_valid_param_value(value):
+            return value
+        else:
+            expected_type_str = _format_seq_to_str(
+                self.get_expected_type(), last_sep="or", remove_type_text=True
+            )
+            msg += f"When setting global config values for `{self.name}`, the values "
+            msg += f"should be of type {expected_type_str}.\n"
+            if self.allowed_values is not None:
+                values_str = _format_seq_to_str(
+                    self.get_allowed_values(), last_sep="or", remove_type_text=True
+                )
+                msg += f"Allowed values should be one of {values_str}. "
+            msg += f"But found {value}."
+            warnings.warn(msg, UserWarning, stacklevel=2)
+            return default_value if default_value is not None else self.default_value

--- a/predictably/tests/__init__.py
+++ b/predictably/tests/__init__.py
@@ -5,3 +5,7 @@
 Tests of core functionality are included here. Tests of specific submodule
 functionality is included in submodule tests.
 """
+from typing import List
+
+__all__: List[str] = []
+__author__: List[str] = ["RNKuhns"]

--- a/predictably/tests/test_config.py
+++ b/predictably/tests/test_config.py
@@ -1,0 +1,381 @@
+# This code reuses some tests in scikit-learn tests/test_config.py
+# The code is copyrighted by the respective scikit-learn developers (BSD-3-Clause
+# License): https://github.com/scikit-learn/scikit-learn/blob/main/COPYING
+"""Test configuration functionality."""
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+from joblib import Parallel, delayed
+
+import predictably as pr
+from predictably._config import _CONFIG_REGISTRY, _GLOBAL_CONFIG_DEFAULT
+from predictably._config_param_setting import GlobalConfigParamSetting
+
+PRINT_CHANGE_ONLY_VALUES = _CONFIG_REGISTRY["print_changed_only"].get_allowed_values()
+DISPLAY_VALUES = _CONFIG_REGISTRY["display"].get_allowed_values()
+DATAFRAME_BACKEND_VALUES = _CONFIG_REGISTRY["dataframe_backend"].get_allowed_values()
+MATH_BACKEND_VALUES = _CONFIG_REGISTRY["math_backend"].get_allowed_values()
+
+
+@pytest.fixture
+def global_config_default():
+    """Config registry fixture."""
+    return _GLOBAL_CONFIG_DEFAULT
+
+
+@pytest.mark.parametrize("allowed_values", (None, (), "something", range(1, 8)))
+def test_global_config_param_get_allowed_values(allowed_values):
+    """Test GlobalConfigParamSetting behavior works as expected."""
+    some_config_param = GlobalConfigParamSetting(
+        name="some_param",
+        expected_type=str,
+        default_value="text",
+        allowed_values=allowed_values,
+    )
+    # Verify we always coerce output of get_allowed_values to tuple
+    values = some_config_param.get_allowed_values()
+    assert isinstance(values, tuple)
+
+
+@pytest.mark.parametrize("expected_type", (None, Any, (), int, (int, str)))
+def test_global_config_param_get_expected_type(expected_type):
+    """Test GlobalConfigParamSetting behavior works as expected."""
+    some_config_param = GlobalConfigParamSetting(
+        name="some_param",
+        expected_type=str,
+        default_value="text",
+        allowed_values=expected_type,
+    )
+    # Verify we always coerce output of get_allowed_values to tuple
+    values = some_config_param.get_expected_type()
+    assert isinstance(values, tuple)
+
+
+@pytest.mark.parametrize("value", (None, (), "wrong_string", "text", range(1, 8)))
+def test_global_config_param_is_valid_param_value(value):
+    """Test GlobalConfigParamSetting behavior works as expected."""
+    some_config_param = GlobalConfigParamSetting(
+        name="some_param",
+        expected_type=str,
+        default_value="text",
+        allowed_values=("text", "diagram"),
+    )
+    # Verify we correctly identify invalid parameters
+    if value in ("text", "diagram"):
+        expected_valid = True
+    else:
+        expected_valid = False
+    assert some_config_param.is_valid_param_value(value) == expected_valid
+
+
+def test_global_config_get_valid_or_default():
+    """Test GlobalConfigParamSetting.get_valid_param_or_default works as expected."""
+    some_config_param = GlobalConfigParamSetting(
+        name="some_param",
+        expected_type=str,
+        default_value="text",
+        allowed_values=("text", "diagram"),
+    )
+
+    # When calling the method with invalid value it should raise user warning
+    with pytest.warns(UserWarning, match=r"When setting global.*"):
+        returned_value = some_config_param.get_valid_param_or_default(7, msg=None)
+
+    # And it should return the default value instead of the passed value
+    assert returned_value == some_config_param.default_value
+
+    # When calling the method with invalid value it should raise user warning
+    # And the warning should start with `msg` if it is passed
+    with pytest.warns(UserWarning, match=r"some message.*"):
+        returned_value = some_config_param.get_valid_param_or_default(
+            7, msg="some message"
+        )
+
+
+def test_get_default_config_always_returns_default(global_config_default):
+    """Test get_default_config always returns the default config."""
+    assert pr.get_default_config() == global_config_default
+    # set config to non-default value to make sure it didn't change
+    # what is returned by get_default_config
+    pr.set_config(print_changed_only=not pr.get_default_config()["print_changed_only"])
+    assert pr.get_default_config() == global_config_default
+    pr.reset_config()
+
+
+@pytest.mark.parametrize("dataframe_backend", DATAFRAME_BACKEND_VALUES)
+@pytest.mark.parametrize("math_backend", MATH_BACKEND_VALUES)
+@pytest.mark.parametrize("print_changed_only", PRINT_CHANGE_ONLY_VALUES)
+@pytest.mark.parametrize("display", DISPLAY_VALUES)
+def test_set_config_then_get_config_returns_expected_value(
+    dataframe_backend, math_backend, print_changed_only, display
+):
+    """Verify that get_config returns set config values if set_config run."""
+    pr.set_config(
+        dataframe_backend=dataframe_backend,
+        math_backend=math_backend,
+        print_changed_only=print_changed_only,
+        display=display,
+    )
+    retrieved_default = pr.get_config()
+    expected_config = {
+        "dataframe_backend": dataframe_backend,
+        "math_backend": math_backend,
+        "print_changed_only": print_changed_only,
+        "display": display,
+    }
+    msg = "`get_config` used after `set_config` does not return expected values.\n"
+    msg += "After set_config is run, get_config should return the set values.\n "
+    msg += f"Expected {expected_config}, but returned {retrieved_default}."
+    assert retrieved_default == expected_config, msg
+    pr.reset_config()
+
+
+def test_set_config_with_none_value():
+    """Verify that setting config param with None value does not update the config."""
+    assert pr.get_config()["print_changed_only"] is True
+    pr.set_config(print_changed_only=None)
+    assert pr.get_config()["print_changed_only"] is True
+
+    pr.set_config(print_changed_only=False)
+    assert pr.get_config()["print_changed_only"] is False
+
+    pr.set_config(print_changed_only=None)
+    assert pr.get_config()["print_changed_only"] is False
+    pr.set_config(print_changed_only=True)
+    assert pr.get_config()["print_changed_only"] is True
+
+    # Test with dataframe_backend
+    assert pr.get_config()["dataframe_backend"] == "polars"
+    pr.set_config(dataframe_backend=None)
+    assert pr.get_config()["dataframe_backend"] == "polars"
+    pr.set_config(dataframe_backend="pandas")
+    assert pr.get_config()["dataframe_backend"] == "pandas"
+
+    pr.set_config(dataframe_backend=None)
+    assert pr.get_config()["dataframe_backend"] == "pandas"
+
+    # Test with math_backend
+    assert pr.get_config()["math_backend"] == "predictably"
+    pr.set_config(math_backend=None)
+    assert pr.get_config()["math_backend"] == "predictably"
+    pr.set_config(math_backend="numba")
+    assert pr.get_config()["math_backend"] == "numba"
+
+    pr.set_config(math_backend=None)
+    assert pr.get_config()["math_backend"] == "numba"
+
+    pr.reset_config()
+
+
+def test_config_context_exception():
+    """Test config_context followed by exception."""
+    assert pr.get_config()["print_changed_only"] is True
+    try:
+        with pr.config_context(print_changed_only=False):
+            assert pr.get_config()["print_changed_only"] is False
+            raise ValueError()
+    except ValueError:
+        pass
+    assert pr.get_config()["print_changed_only"] is True
+
+    assert pr.get_config()["dataframe_backend"] == "polars"
+    try:
+        with pr.config_context(dataframe_backend="pandas"):
+            assert pr.get_config()["dataframe_backend"] == "pandas"
+            raise ValueError()
+    except ValueError:
+        pass
+    assert pr.get_config()["dataframe_backend"] == "polars"
+
+    pr.reset_config()
+
+
+@pytest.mark.parametrize("dataframe_backend", DATAFRAME_BACKEND_VALUES)
+@pytest.mark.parametrize("math_backend", MATH_BACKEND_VALUES)
+@pytest.mark.parametrize("print_changed_only", PRINT_CHANGE_ONLY_VALUES)
+@pytest.mark.parametrize("display", DISPLAY_VALUES)
+def test_reset_config_resets_the_config(
+    dataframe_backend, math_backend, print_changed_only, display, global_config_default
+):
+    """Verify that get_config returns default config if reset_config run."""
+    pr.set_config(
+        dataframe_backend=dataframe_backend,
+        math_backend=math_backend,
+        print_changed_only=print_changed_only,
+        display=display,
+    )
+    pr.reset_config()
+    retrieved_config = pr.get_config()
+
+    msg = "`get_config` does not return expected values after `reset_config`.\n"
+    msg += "`After reset_config is run, get_config` should return defaults.\n"
+    msg += f"Expected {global_config_default}, but returned {retrieved_config}."
+    assert retrieved_config == global_config_default, msg
+    pr.reset_config()
+
+
+@pytest.mark.parametrize("dataframe_backend", DATAFRAME_BACKEND_VALUES)
+@pytest.mark.parametrize("math_backend", MATH_BACKEND_VALUES)
+@pytest.mark.parametrize("print_changed_only", PRINT_CHANGE_ONLY_VALUES)
+@pytest.mark.parametrize("display", DISPLAY_VALUES)
+def test_config_context(dataframe_backend, math_backend, print_changed_only, display):
+    """Verify that config_context affects context but not overall configuration."""
+    # Make sure config is reset to default values then retrieve it
+    pr.reset_config()
+    retrieved_config = pr.get_config()
+
+    # Verify that nothing happens if not used as context manager
+    pr.config_context(print_changed_only=print_changed_only)
+    assert pr.get_config() == retrieved_config
+    pr.config_context(math_backend=math_backend)
+    assert pr.get_config() == retrieved_config
+
+    # Now lets make sure the config_context is changing the context of those values
+    # within the scope of the context manager as expected
+    with pr.config_context(
+        dataframe_backend=dataframe_backend,
+        math_backend=math_backend,
+        print_changed_only=print_changed_only,
+        display=display,
+    ):
+        retrieved_context_config = pr.get_config()
+    expected_config = {
+        "dataframe_backend": dataframe_backend,
+        "math_backend": math_backend,
+        "print_changed_only": print_changed_only,
+        "display": display,
+    }
+    msg = "`get_config` does not return expected values within `config_context`.\n"
+    msg += "`get_config` should return config defined by `config_context`.\n"
+    msg += f"Expected {expected_config}, but returned {retrieved_context_config}."
+    assert retrieved_context_config == expected_config, msg
+
+    # Outside of the config_context we should have not affected the retrieved config
+    # set by call to reset_config()
+    config_post_config_context = pr.get_config()
+    msg = "`get_config` does not return expected values after `config_context`a.\n"
+    msg += "`config_context` should not affect configuration outside its context.\n"
+    msg += f"Expected {config_post_config_context}, but returned {retrieved_config}."
+    assert retrieved_config == config_post_config_context, msg
+
+    # positional arguments not allowed
+    with pytest.raises(TypeError):
+        pr.config_context(True)
+
+    # Unknown arguments raise exception
+    with pytest.raises(TypeError):
+        pr.config_context(do_something_else=True).__enter__()
+
+
+def test_nested_config_context():
+    """Verify that nested config_context works as expected."""
+    # Verify nested attempt to set None value does not work
+    with pr.config_context(print_changed_only=False):
+        with pr.config_context(print_changed_only=None):
+            assert pr.get_config()["print_changed_only"] is False
+
+        assert pr.get_config()["print_changed_only"] is False
+
+        with pr.config_context(print_changed_only=True):
+            assert pr.get_config()["print_changed_only"] is True
+
+            with pr.config_context(print_changed_only=None):
+                assert pr.get_config()["print_changed_only"] is True
+
+                # global setting will not be retained outside of context that
+                # did not modify this setting
+                pr.set_config(print_changed_only=False)
+                assert pr.get_config()["print_changed_only"] is False
+
+            assert pr.get_config()["print_changed_only"] is True
+
+        assert pr.get_config()["print_changed_only"] is False
+    assert pr.get_config()["print_changed_only"] is True
+    pr.reset_config()
+
+
+def test_set_config_behavior_invalid_value():
+    """Test set_config uses default and raises warning when setting invalid value."""
+    match = r"Attempting to set an invalid value.*"
+    pr.reset_config()
+    original_config = pr.get_config()
+    with pytest.warns(UserWarning, match=match):
+        pr.set_config(print_changed_only="False")
+    assert pr.get_config() == original_config
+
+    original_config = pr.get_config()
+    with pytest.warns(UserWarning, match=match):
+        pr.set_config(print_changed_only=7)
+    assert pr.get_config() == original_config
+
+    original_config = pr.get_config()
+    with pytest.warns(UserWarning, match=match):
+        pr.set_config(math_backend="polars")
+    assert pr.get_config() == original_config
+
+    original_config = pr.get_config()
+    with pytest.warns(UserWarning, match=match):
+        pr.set_config(dataframe_backend="numba")
+    assert pr.get_config() == original_config
+    pr.reset_config()
+
+
+def test_set_config_invalid_keyword_argument():
+    """Test set_config behavior when invalid keyword argument passed."""
+    with pytest.raises(TypeError):
+        pr.set_config(do_something_else=True)
+
+    with pytest.raises(TypeError):
+        pr.set_config(True)
+
+
+def _set_print_changed_only(print_changed_only, sleep_duration):
+    """Return the value of print_changed_only after waiting `sleep_duration`."""
+    with pr.config_context(print_changed_only=print_changed_only):
+        time.sleep(sleep_duration)
+        return pr.get_config()["print_changed_only"]
+
+
+def test_config_threadsafe():
+    """Test config is actually threadsafe.
+
+    Uses threads directly to test that the global config does not change
+    between threads. Same test as `test_config_threadsafe_joblib` but with
+    `ThreadPoolExecutor`.
+    """
+
+    print_changed_only_vals = [False, True, False, True]
+    sleep_durations = [0.1, 0.2, 0.1, 0.2]
+
+    with ThreadPoolExecutor(max_workers=2) as e:
+        items = list(
+            e.map(_set_print_changed_only, print_changed_only_vals, sleep_durations)
+        )
+
+    assert items == [False, True, False, True]
+    pr.reset_config()
+
+
+@pytest.mark.parametrize("backend", ["loky", "multiprocessing", "threading"])
+def test_config_threadsafe_joblib(backend):
+    """Test that the global config is threadsafe with all joblib backends.
+
+    Two jobs are spawned and sets assume_finite to two different values.
+    When the job with a duration 0.1s completes, the assume_finite value
+    should be the same as the value passed to the function. In other words,
+    it is not influenced by the other job setting assume_finite to True.
+    """
+    print_changed_only_vals = [False, True, False, True]
+    sleep_durations = [0.1, 0.2, 0.1, 0.2]
+
+    items = Parallel(backend=backend, n_jobs=2)(
+        delayed(_set_print_changed_only)(print_changed_only, sleep_dur)
+        for print_changed_only, sleep_dur in zip(
+            print_changed_only_vals, sleep_durations
+        )
+    )
+
+    assert items == [False, True, False, True]
+    pr.reset_config()

--- a/predictably/tests/test_config.py
+++ b/predictably/tests/test_config.py
@@ -92,6 +92,8 @@ def test_global_config_get_valid_or_default_warns() -> None:
         returned_value = some_config_param.get_valid_param_or_default(
             7, msg="some message"
         )
+    # And it should return the default value instead of the passed value
+    assert returned_value == some_config_param.default_value
 
 
 def test_get_default_config_always_returns_default(global_config_default):

--- a/predictably/tests/test_config.py
+++ b/predictably/tests/test_config.py
@@ -70,8 +70,8 @@ def test_global_config_param_is_valid_param_value(value):
     assert some_config_param.is_valid_param_value(value) == expected_valid
 
 
-def test_global_config_get_valid_or_default():
-    """Test GlobalConfigParamSetting.get_valid_param_or_default works as expected."""
+def test_global_config_get_valid_or_default_warns() -> None:
+    """Test GlobalConfigParamSetting.get_valid_param_or_default warns on invalid."""
     some_config_param = GlobalConfigParamSetting(
         name="some_param",
         expected_type=str,
@@ -81,7 +81,7 @@ def test_global_config_get_valid_or_default():
 
     # When calling the method with invalid value it should raise user warning
     with pytest.warns(UserWarning, match=r"When setting global.*"):
-        returned_value = some_config_param.get_valid_param_or_default(7, msg=None)
+        returned_value = some_config_param.get_valid_param_or_default(7)
 
     # And it should return the default value instead of the passed value
     assert returned_value == some_config_param.default_value

--- a/predictably/utils/__init__.py
+++ b/predictably/utils/__init__.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3 -u
+# copyright: predict-ably, BSD-3-Clause License (see LICENSE file)
+# Elements of predictably.utils reuse code developed for skbase. These elements
+# are copyrighted by the skbase developers, BSD-3-Clause License. For
+# conditions see https://github.com/sktime/skbase/blob/main/LICENSE
+""":mod:`predictably.utils` includes utility functionality used through `predictably`.
+
+This module includes general utilities. Statistical utilities will be kept in
+predictably.stats.utils.
+"""
+from typing import List
+
+__author__: List[str] = ["RNKuhns"]
+__all__: List[str] = []

--- a/predictably/utils/_iter.py
+++ b/predictably/utils/_iter.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3 -u
+# copyright: predict-ably, BSD-3-Clause License (see LICENSE file)
+# Elements of predictably.utils reuse code developed for skbase. These elements
+# are copyrighted by the skbase developers, BSD-3-Clause License. For
+# conditions see https://github.com/sktime/skbase/blob/main/LICENSE
+"""Utility functionality for working with sequences."""  # numpydoc ignore=ES01
+import re
+from collections.abc import Sequence
+from typing import Any, List, Optional, Union
+
+__author__: List[str] = ["RNKuhns"]
+__all__: List[str] = [
+    "_scalar_to_seq",
+    "_remove_single",
+    "_remove_type_text",
+    "_format_seq_to_str",
+]
+
+
+def _remove_single(x: Sequence[Any]) -> Any:
+    """Remove tuple wrapping from singleton.
+
+    If the input has length 1, then the single value is extracted from the input.
+    Otherwise, the input is returned unchanged.
+
+    Parameters
+    ----------
+    x : Sequence
+        The sequence to remove a singleton value from.
+
+    Returns
+    -------
+    Any
+        The singleton value of x if x[0] is a singleton, otherwise x.
+
+    Examples
+    --------
+    >>> from predictably.utils._iter import _remove_single
+    >>> _remove_single([1])
+    1
+    >>> _remove_single([1, 2, 3])
+    [1, 2, 3]
+    """
+    if len(x) == 1:
+        return x[0]
+    else:
+        return x
+
+
+def _scalar_to_seq(scalar: Any, sequence_type: Optional[type] = None) -> Sequence[Any]:
+    """Convert a scalar input to a sequence.
+
+    If the input is already a sequence it is returned unchanged. Unlike standard
+    Python, a string is treated as a scalar instead of a sequence.
+
+    Parameters
+    ----------
+    scalar : Any
+        A scalar input to be converted to a sequence.
+    sequence_type : type, default=None
+        A sequence type (e.g., list, tuple) that is used to set the return type. This
+        is ignored if `scalar` is already a sequence other than a str (which is
+        treated like a scalar type for this function instead of sequence of
+        characters).
+
+        - If None, then the returned sequence will be a tuple containing a single
+          scalar element.
+        - If `sequence_type` is a valid sequence type then the returned
+          sequence will be a sequence of that type containing the single scalar
+          value.
+
+    Returns
+    -------
+    Sequence
+        A sequence of the specified `sequence_type` that contains just the single
+        scalar value.
+
+    Examples
+    --------
+    >>> from predictably.utils._iter import _scalar_to_seq
+    >>> _scalar_to_seq(7)
+    (7,)
+    >>> _scalar_to_seq("some_str")
+    ('some_str',)
+    >>> _scalar_to_seq("some_str", sequence_type=list)
+    ['some_str']
+    >>> _scalar_to_seq((1, 2))
+    (1, 2)
+    """
+    # We'll treat str like regular scalar and not a sequence
+    if isinstance(scalar, Sequence) and not isinstance(scalar, str):
+        return scalar
+    elif sequence_type is None:
+        return (scalar,)
+    elif issubclass(sequence_type, Sequence) and sequence_type != Sequence:
+        # Note calling (scalar,) is done to avoid str unpacking
+        return sequence_type((scalar,))  # type: ignore
+    else:
+        raise ValueError(
+            "`sequence_type` must be a subclass of collections.abc.Sequence."
+        )
+
+
+def _remove_type_text(input_: Union[str, type]) -> str:
+    """Remove <class > wrapper from printed type str.
+
+    If the input doesn't have the wrapper <class > text it is returned unchanged.
+
+    Parameters
+    ----------
+    input_ : str | type
+        The input to remove <class > wrapper when printing class.
+
+    Returns
+    -------
+    str
+        The text version of the class without the <class > wrapper.
+
+    Examples
+    --------
+    >>> from predictably.utils._iter import _remove_type_text
+    >>> _remove_type_text(int)
+    'int'
+    >>> _remove_type_text("<class 'int'>")
+    'int'
+    >>> _remove_type_text("int")
+    'int'
+    """
+    if not isinstance(input_, str):
+        input_ = str(input_)
+
+    m = re.match("^<class '(.*)'>$", input_)
+    if m:
+        return m[1]
+    else:
+        return input_
+
+
+def _format_seq_to_str(
+    seq: Union[Any, Sequence[Any]],
+    sep: str = ", ",
+    last_sep: Optional[str] = None,
+    remove_type_text: bool = False,
+) -> str:
+    """Format a sequence to a string of delimited elements.
+
+    This is useful to format sequences into a pretty printing format for
+    creating error messages or warnings.
+
+    Parameters
+    ----------
+    seq : Any | Sequence[Any]
+        The input sequence to convert to a str of the elements separated by `sep`.
+    sep : str
+        The separator to use when creating the str output.
+    last_sep : str, default=None
+        The separator to use prior to last element.
+
+        - If None, then `sep` is used. So (7, 9, 11) return "7", "9", "11" for
+          ``sep=", "``.
+        - If last_sep is a str, then it is used prior to last element. So
+          (7, 9, 11) would be "7", "9" and "11" if ``last_sep="and"``.
+
+    remove_type_text : bool, default=False
+        Whether to remove the <class > text wrapping the class type name, when
+        formatting types.
+
+        - If True, then input sequence [list, tuple] returns "list, tuple"
+        - If False, then input sequence [list, tuple] returns
+          "<class 'list'>, <class 'tuple'>".
+
+    Returns
+    -------
+    str
+        The sequence of inputs converted to a string. For example, if `seq`
+        is (7, 9, "cart") and ``last_sep is None`` then the output is "7", "9", "cart".
+
+    Examples
+    --------
+    >>> from predictably.utils._iter import _format_seq_to_str
+    >>> seq = [1, 2, 3, 4]
+    >>> _format_seq_to_str(seq)
+    '1, 2, 3, 4'
+    >>> _format_seq_to_str(seq, last_sep="and")
+    '1, 2, 3 and 4'
+    >>> _format_seq_to_str(seq, last_sep="or")
+    '1, 2, 3 or 4'
+    """
+    if isinstance(seq, str):
+        return seq
+    # Allow casting of scalars to strings
+    elif isinstance(seq, (int, float, bool)):
+        return str(seq)
+    elif isinstance(seq, type):
+        if remove_type_text:
+            return _remove_type_text(str(seq))
+        else:
+            return str(seq)
+    elif not isinstance(seq, Sequence):
+        msg = "`seq` must be a sequence or scalar str, int, float, bool or type."
+        msg += f"\nBut found {type(seq)}."
+        raise TypeError(msg)
+
+    seq_str = [str(e) for e in seq]
+    if remove_type_text:
+        seq_str = [_remove_type_text(s) for s in seq_str]
+
+    if last_sep is None:
+        output_str = sep.join(seq_str)
+    else:
+        if len(seq_str) == 1:
+            output_str = _remove_single(seq_str)
+        else:
+            output_str = sep.join(e for e in seq_str[:-1])
+            output_str = output_str + f" {last_sep} " + seq_str[-1]
+
+    return output_str

--- a/predictably/utils/_iter.py
+++ b/predictably/utils/_iter.py
@@ -4,9 +4,9 @@
 # are copyrighted by the skbase developers, BSD-3-Clause License. For
 # conditions see https://github.com/sktime/skbase/blob/main/LICENSE
 """Utility functionality for working with sequences."""  # numpydoc ignore=ES01
+import collections
 import re
-from collections.abc import Sequence
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Sequence, Union
 
 __author__: List[str] = ["RNKuhns"]
 __all__: List[str] = [
@@ -88,11 +88,14 @@ def _scalar_to_seq(scalar: Any, sequence_type: Optional[type] = None) -> Sequenc
     (1, 2)
     """
     # We'll treat str like regular scalar and not a sequence
-    if isinstance(scalar, Sequence) and not isinstance(scalar, str):
+    if isinstance(scalar, collections.abc.Sequence) and not isinstance(scalar, str):
         return scalar
     elif sequence_type is None:
         return (scalar,)
-    elif issubclass(sequence_type, Sequence) and sequence_type != Sequence:
+    elif (
+        issubclass(sequence_type, collections.abc.Sequence)
+        and sequence_type != Sequence
+    ):
         # Note calling (scalar,) is done to avoid str unpacking
         return sequence_type((scalar,))  # type: ignore
     else:
@@ -196,7 +199,7 @@ def _format_seq_to_str(
             return _remove_type_text(str(seq))
         else:
             return str(seq)
-    elif not isinstance(seq, Sequence):
+    elif not isinstance(seq, collections.abc.Sequence):
         msg = "`seq` must be a sequence or scalar str, int, float, bool or type."
         msg += f"\nBut found {type(seq)}."
         raise TypeError(msg)

--- a/predictably/utils/tests/__init__.py
+++ b/predictably/utils/tests/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3 -u
+# copyright: predict-ably, BSD-3-Clause License (see LICENSE file)
+# Elements of predictably.utils reuse code developed for skbase. These elements
+# are copyrighted by the skbase developers, BSD-3-Clause License. For
+# conditions see https://github.com/sktime/skbase/blob/main/LICENSE
+"""Tests of predictably.utils functionality."""

--- a/predictably/utils/tests/test_iter.py
+++ b/predictably/utils/tests/test_iter.py
@@ -82,6 +82,9 @@ def test_format_seq_to_str() -> None:
         == "list and tuple"
     )
 
+    assert _format_seq_to_str(int) == "<class 'int'>"
+    assert _format_seq_to_str(int, remove_type_text=True) == "int"
+
     # Test with scalar inputs
     assert _format_seq_to_str(7) == "7"  # int, float, bool primitives cast to str
     assert _format_seq_to_str("some_str") == "some_str"

--- a/predictably/utils/tests/test_iter.py
+++ b/predictably/utils/tests/test_iter.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3 -u
+# copyright: predict-ably, BSD-3-Clause License (see LICENSE file)
+# Elements of predictably.utils reuse code developed for skbase. These elements
+# are copyrighted by the skbase developers, BSD-3-Clause License. For
+# conditions see https://github.com/sktime/skbase/blob/main/LICENSE
+"""Tests of the functionality for working with iterables.
+
+tests in this module incdlue:
+
+- test_remove_single: verify that _remove_single works as expected.
+- test_format_seq_to_str: verify that _format_seq_to_str outputs expected format.
+- test_format_seq_to_str_raises: verify _format_seq_to_str raises error on unexpected
+  output.
+- test_scalar_to_seq_expected_output: verify that _scalar_to_seq returns expected
+  output.
+- test_scalar_to_seq_raises: verify that _scalar_to_seq raises error when an
+  invalid value is provided for sequence_type parameter.
+"""
+from collections.abc import Sequence
+
+import pytest
+
+from predictably.utils._iter import (
+    _format_seq_to_str,
+    _remove_single,
+    _remove_type_text,
+    _scalar_to_seq,
+)
+
+__author__ = ["RNKuhns"]
+
+
+class SomeClass:
+    """This is a test class."""
+
+    def __init__(self, a: int = 7) -> None:
+        self.a = a
+
+
+def test_remove_type_text() -> None:
+    """Test _remove_type_text removes <class ... > text as expected."""
+    msg = "Not removing type text from type"
+    assert _remove_type_text(int) == "int", msg
+    assert _remove_type_text(Sequence) == "collections.abc.Sequence", msg
+    msg = "Not removing type text from str"
+    assert _remove_type_text("<class 'int'>") == "int", msg
+    msg = "Not leaving strings without <class ...> text unchanged."
+    assert _remove_type_text("int") == "int", msg
+    assert _remove_type_text("<type 'int'>") == "<type 'int'>", msg
+
+
+def test_remove_single() -> None:
+    """Test _remove_single output is as expected."""
+    # Verify that length > 1 sequence not impacted.
+    assert _remove_single([1, 2, 3]) == [1, 2, 3]
+
+    # Verify single member of sequence is removed as expected
+    assert _remove_single([1]) == 1
+
+
+def test_format_seq_to_str() -> None:
+    """Test _format_seq_to_str returns expected output."""
+    # Test basic functionality (including ability to handle str and non-str)
+    seq = [1, 2, "3", 4]
+    assert _format_seq_to_str(seq) == "1, 2, 3, 4"
+
+    # Test use of last_sep
+    assert _format_seq_to_str(seq, last_sep="and") == "1, 2, 3 and 4"
+    assert _format_seq_to_str(seq, last_sep="or") == "1, 2, 3 or 4"
+
+    # Test use of different sep argument
+    assert _format_seq_to_str(seq, sep=";") == "1;2;3;4"
+
+    # Test using remove_type_text keyword
+    assert (
+        _format_seq_to_str([list, tuple], remove_type_text=False)
+        == "<class 'list'>, <class 'tuple'>"
+    )
+    assert _format_seq_to_str([list, tuple], remove_type_text=True) == "list, tuple"
+    assert (
+        _format_seq_to_str([list, tuple], last_sep="and", remove_type_text=True)
+        == "list and tuple"
+    )
+
+    # Test with scalar inputs
+    assert _format_seq_to_str(7) == "7"  # int, float, bool primitives cast to str
+    assert _format_seq_to_str("some_str") == "some_str"
+    # Verify that keywords don't affect output
+    assert _format_seq_to_str(7, sep=";") == "7"
+    assert _format_seq_to_str(7, last_sep="or") == "7"
+
+
+def test_format_seq_to_str_raises() -> None:
+    """Test _format_seq_to_str raises error when input is unexpected type."""
+    with pytest.raises(
+        TypeError, match="`seq` must be a sequence or scalar str, int, float or bool..*"
+    ):
+        _format_seq_to_str(c for c in [1, 2, 3])
+
+    with pytest.raises(
+        TypeError, match="`seq` must be a sequence or scalar str, int, float or bool..*"
+    ):
+        _format_seq_to_str(object)
+
+
+def test_scalar_to_seq_expected_output() -> None:
+    """Test _scalar_to_seq returns expected output."""
+    assert _scalar_to_seq(7) == (7,)
+    # Verify it works with scalar classes and objects
+    assert _scalar_to_seq(int) == (int,)
+    assert _scalar_to_seq(SomeClass) == (SomeClass,)
+    # Verify strings treated like scalar not sequence
+    assert _scalar_to_seq("some_str") == ("some_str",)
+    assert _scalar_to_seq("some_str", sequence_type=list) == ["some_str"]
+
+    # Verify sequences returned unchanged
+    assert _scalar_to_seq((1, 2)) == (1, 2)
+
+
+def test_scalar_to_seq_raises() -> None:
+    """Test scalar_to_seq raises error when `sequence_type` is unexpected type."""
+    with pytest.raises(
+        ValueError,
+        match="`sequence_type` must be a subclass of collections.abc.Sequence.",
+    ):
+        _scalar_to_seq(7, sequence_type=int)
+
+    with pytest.raises(
+        ValueError,
+        match="`sequence_type` must be a subclass of collections.abc.Sequence.",
+    ):
+        _scalar_to_seq(7, sequence_type=dict)

--- a/predictably/utils/tests/test_iter.py
+++ b/predictably/utils/tests/test_iter.py
@@ -93,14 +93,9 @@ def test_format_seq_to_str() -> None:
 def test_format_seq_to_str_raises() -> None:
     """Test _format_seq_to_str raises error when input is unexpected type."""
     with pytest.raises(
-        TypeError, match="`seq` must be a sequence or scalar str, int, float or bool..*"
+        TypeError, match="`seq` must be a sequence or scalar str, int, float, bool.*"
     ):
         _format_seq_to_str(c for c in [1, 2, 3])
-
-    with pytest.raises(
-        TypeError, match="`seq` must be a sequence or scalar str, int, float or bool..*"
-    ):
-        _format_seq_to_str(object)
 
 
 def test_scalar_to_seq_expected_output() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-all_extras = ["numpy", "pandas", "xarray", "pyarrow"]
+all_extras = ["numba", "numpy", "pandas", "fugue", "pyarrow"]
+
+cuda = ["cudf", "cupy"]
 
 dev = [
     "pre-commit",
@@ -78,6 +80,7 @@ test = [
     "pytest",
     "coverage",
     "pytest-cov",
+    "joblib",
 ]
 
 [project.urls]
@@ -134,7 +137,12 @@ exclude_dirs = ["*/tests/*", "*/testing/*"]
 
 [tool.numpydoc_validation]
 checks = ["all", "GL01", "SA01", "EX01"]
-exclude = ["\\.__init__$"]
+exclude = [
+    "\\.*tests.*",
+    "\\.__init__$",
+    "__init__$",
+    ".*tests.*"
+]
 
 [tool.setuptools]
 zip-safe = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,6 @@ inline-quotes = double
 extend-ignore = E203
 extend-select = B904, B907
 exclude = .git, __pycache__, docs/source/conf.py, build, dist
+
+[mypy]
+ignore_missing_imports = True


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://predictably.readthedocs.io/en/latest/contribute.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented. Remember to implement
unit tests and docstrings if your pull request commits code to the repository.
-->

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution requires a new dependency please indicate why it is necessary.
predictably seeks to minimize dependencies to make it easy to use predictably in a variety
of environments and contexts.
-->

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Any other comments?
<!--
Is there any other information the reviewer should know?
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
-  [ ] I've reviewed the project documentation on [contributing](https://predictably.readthedocs.io/en/latest/contribute.html)
-  [ ] I've added myself to the [list of contributors](https://github.com/predict-ably/predictably/blob/main/.all-contributorsrc).
-  [x] The PR title starts with either [ENH], [CI/CD], [MNT], [DOC], or [BUG] indicating whether
  the PR topic is related to enhancement, CI/CD, maintenance, documentation, or a bug.

##### For code contributions
-  [x] Unit tests have been added covering code functionality
-  [x] Appropriate docstrings have been added (see [documentation standards](https://predictably.readthedocs.io/en/latest/contribute/development/developer_guide/creating_docs.html))
-  [ ] New public functionality has been added to the API Reference


<!--
Thanks for contributing!
-->
