### PR TITLE
Add initial documentation

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -1,0 +1,63 @@
+.. _top_level_about:
+
+=====
+About
+=====
+
+Learn more about the ``predictably`` project and its community.
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   about/mission
+   about/history
+   about/team
+   about/contributors
+   about/governance
+   about/roadmap
+
+.. grid:: 1 2 2 2
+    :gutter: 3
+
+    .. grid-item-card:: Mission
+        :text-align: left
+        :link: about/mission
+        :link-type: doc
+
+        ``predictably``'s mission.
+
+    .. grid-item-card:: History
+        :text-align: left
+        :link: about/history
+        :link-type: doc
+
+        Learn about ``predictably``'s history.
+
+    .. grid-item-card:: Development Team
+        :text-align: left
+        :link: about/team
+        :link-type: doc
+
+        ``predictably``'s core development team.
+
+    .. grid-item-card:: Contributors
+        :text-align: left
+        :link: about/contributors
+        :link-type: doc
+
+        All of ``predictably``'s contributors.
+
+    .. grid-item-card:: Governance
+        :text-align: left
+        :link: about/governance
+        :link-type: doc
+
+        How we govern the project.
+
+    .. grid-item-card:: Roadmap
+        :text-align: left
+        :link: about/roadmap
+        :link-type: doc
+
+        Where we plan to take ``predictably``.

--- a/docs/source/about/contributors.md
+++ b/docs/source/about/contributors.md
@@ -1,0 +1,2 @@
+```{include} ../../../CONTRIBUTORS.md
+```

--- a/docs/source/about/governance.rst
+++ b/docs/source/about/governance.rst
@@ -1,0 +1,240 @@
+.. _governance:
+
+==========
+Governance
+==========
+
+Overview
+========
+
+``predictably`` is a consensus-based project that is part of the ``predictably``
+community. Anyone with an interest in the project can join the community, contribute
+to the project, and participate in the governance process. The rest of this document
+describes how that participation takes place, which roles we have in our community,
+how we make decisions, and how we acknowledge contributions.
+
+.. note::
+
+    As a new project, ``predictably`` has adopted a provision governance structure.
+    We expect this to change as the project grows.
+
+.. _gov_coc:
+
+Code of Conduct
+===============
+
+The ``predictably`` project believes that everyone should be able to participate
+in our community without fear of harassment or discrimination (see our
+:ref:`Code of Conduct guide <coc>`).
+
+Roles
+=====
+
+``predictably`` distinguishes between the following key community roles:
+
+- :ref:`Contributors <contribs>`
+- :ref:`Core developers <core-devs>`
+- :ref:`Steering Committee <steering_committee>`
+
+.. _contribs:
+
+Contributors
+------------
+
+Anyone is welcome to contribute to the project. Contributions can take many
+forms – not only code – as detailed in the :ref:`contributing guide <how_to_contrib>`
+
+For more details on how we acknowledge contributions,
+see the :ref:`acknowledging contributions <acknowledging>` section below.
+
+All of our contributors are listed under the `contributors <contributors.md>`_
+section of our documentation.
+
+.. _core-devs:
+
+Core developers
+---------------
+
+Core developers are contributors who have shown dedication to project's development
+through ongoing engagement with the community (
+see the :ref:`core development team <team>`).
+
+The :ref:`core developmer team <team>`  helps ensure the smooth functioning of
+the project by:
+
+- ongoing engagement with community
+- managing issues and Pull Requests
+- closing resolved issues
+- reviewing others contributions in accordance with the project
+  :ref:`reviewers guide <rev_guide>`)
+- approving and merging Pull Requests
+- participating in the project's decision making process
+- nominating new core developers and steering committee members
+
+Any core developer nominee must receive affirmative votes from two-thirds of
+existing core developers over the course of a 5 business day voting period.
+
+Core developers can remain in their role for as long as they like as long as they
+continue to perform the role's duties. Core developers who no longer want to
+perform the role's duties can resign at any time, while core developers that become
+inactive for a 12-month period will move to a "former" core developer status.
+
+.. _steering_committee:
+
+Steering Committee
+------------------
+
+Steering Committee (SC) :ref:`team members <team>` are core developers with
+additional rights and responsibilities for maintaining the project, including:
+
+- providing technical direction
+- strategic planning, roadmapping and project management
+- managing community infrastructure (e.g., Github repository, etc)
+- fostering collaborations with external organisations
+- avoiding deadlocks and ensuring a smooth functioning of the project
+
+SC nominees must be nominated by an existing core developer and receive
+affirmative votes from two-thirds of core developers and a simple majority
+(with tie breaking) of existing SC members.
+
+Like core developers, SC members who continue to engage with the project
+can serve as long as they'd like. However, SC members who do not actively engage
+in their SC responsibilities are expected to resign. In the event, a SC member
+who no longer engages in their responsibilities does not resign, the remaining
+SC members and core developers can vote to remove them (same voting rules
+as appointment).
+
+.. _decisions:
+
+Decision making
+===============
+
+The ``predictably`` community tries to take viewpoints and feedback from all
+community members into account when making decisions in order to arrive at
+consensus decisions.
+
+To accomplish this, this section outlines the decision-making process used
+by the project.
+
+Where we make decisions
+-----------------------
+
+Most of the project's decisions and voting takes place on the project’s `issue
+tracker <https://github.com/predict-ably/predictably/issues>`__,
+`pull requests <https://github.com/predict-ably/predictably/pulls>`__ or an
+:ref:`enhancement proposal <gov_bep>`. However, some sensitive discussions and
+all appointment votes occur on private chats.
+
+Core developers are expected to express their consensus (or veto) in the medium
+where a given decision takes place. For changes included in the Project's issues
+and Pull Requests, this is through comments or Github's built-in review process.
+
+Types of decisions
+------------------
+
+The consensus based decision-making process for major types of project
+decisions are summarized below.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Type of change
+     - Decision making process
+   * - Code additions or changes
+     - :ref:`Lazy consensus <lazy>`
+   * - Documentation changes
+     - :ref:`Lazy consensus <lazy>`
+   * - Changes to the API design, hard dependencies, or supported versions
+     - :ref:`Lazy consensus <lazy>` based on an :ref:`PREP <gov_bep>`
+   * - Changes to predictably's governance
+     - :ref:`Lazy consensus <lazy>` based on an :ref:`PREP <gov_bep>`
+   * - Appointment to core developer or steering committee status
+     - Anonymous voting on slack
+
+
+How we make decisions
+---------------------
+
+.. _lazy:
+
+Lazy consensus
+^^^^^^^^^^^^^^
+
+Changes are approved "lazily" when after *reasonable* amount of time
+the change receives approval from at least one core developer
+and no rejections from any core developers.
+
+This is approach is designed to make it easier to add new features and make changes
+to the project as it develops. To make sure things run smoothly,
+:ref:`core developers <core-devs>` should make sure that the *reasonable* time
+other community members have to provide feedback on the changes is commensurate
+to the scope of the change. For changes to the API or other larger changes,
+core developers should actively solicit feedback from their peers.
+
+.. _gov_bep:
+
+``predictably`` enhancement proposals
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Project design decisions have a more detailed approval process,
+commensurate with their broader impact on the project. Any changes
+to the project's core API design, hard dependencies or supported versions
+should first be presented in a ``predictably`` enhancement proposal (PREP).
+
+See the developer guide for more information on creating a :ref:`PREP <bep>`.
+
+Resolving conflicts
+^^^^^^^^^^^^^^^^^^^
+
+When consensus can't be found lazily, the project's core developers will vote
+to decide how to proceed on an issue. Any core developers can call for a vote
+on a topic. A topic must receive two-thirds of core developer votes cast
+(abstentions are allowed) via comments on the relevant issue or
+Pull Request over a 5 day voting period.
+
+In the event a proposed change does not gather the necesssary votes, then:
+
+- The core developer who triggered the vote can choose to drop the issue
+- The proposed changes can be escalated to the SC, who will seek to learn more
+  about the team member viewpoints, before bringing the topic up for a simple
+  majority vote of SC members.
+
+.. _acknowledging:
+
+Acknowledging contributions
+===========================
+
+The ``predictably`` project values all kinds of contributions and the
+development team is committed to recognising each of them fairly.
+
+The project follows the `all-contributors <https://allcontributors.org>`_
+specification to recognise all contributors, including those that don’t
+contribute code. Please see our list of `all contributors <contributors.md>`_.
+
+Please let us know or open a PR with the appropriate changes to
+`predictably/.all-contributorsrc
+<https://github.com/predict-ably/predictably/blob/main/.all-contributorsrc>`_
+if we have missed anything.
+
+.. note::
+
+  ``predictably`` is an open-source project. All code is contributed
+  under `our open-source
+  license <https://github.com/sktime/baseobject/blob/main/LICENSE>`_.
+  Contributors acknowledge that they have rights to make their contribution
+  (code or otherwise) available under this license.
+
+Outlook
+=======
+
+As with other parts of the project, the governance may change as the project
+matures. Suggestions on potential governance changes are also welcome.
+
+References
+==========
+
+Our governance model is inspired by various existing governance
+structures. In particular, we'd like to acknowledge:
+
+* `sktime's governance model <https://www.sktime.org/en/latest/get_involved/governance.htmls>`_
+* `scikit-learn's governance model <https://scikit-learn.org/stable/governance.html>`_

--- a/docs/source/about/history.rst
+++ b/docs/source/about/history.rst
@@ -1,0 +1,22 @@
+.. _history:
+
+=======
+History
+=======
+
+``predictably`` was started in August 2023 by Ryan Kuhns in an effort to make it
+easier to use statistical, econometric and machine learning techniques in a consistent
+way across platforms and functional areas.
+
+The project builds on and was heavily inspired by
+`scikit-learn`_ and `sktime`_ and its Python interface follows these projects closely.
+
+Development is supported by the project's steering committee, core developers
+and the broader community (see `contributors <contributors.md>`_).
+
+If you are interested in contributing, check out our
+:ref:`Contributing <contrib_guide>` guide.
+
+.. _scikit-learn: https://scikit-learn.org/stable/index.html
+.. _BaseEstimator API: https://scikit-learn.org/stable/developers/develop.html
+.. _sktime: https://www.sktime.org/en/stable/index.html

--- a/docs/source/about/mission.rst
+++ b/docs/source/about/mission.rst
@@ -1,0 +1,16 @@
+.. _mission:
+
+=======
+Mission
+=======
+
+The goal of the ``predictably`` is to make it easier for end users from a vareity
+of backgrounds to use of statistical, econometric and machine learning
+approaches to make better predictions.
+
+Our goal is to help users predict *ably*.
+
+Check out our :ref:`roadmap` for more details on how we plan achieve our mission.
+
+.. _scikit-learn: https://scikit-learn.org/stable/index.html
+.. _sktime: https://www.sktime.org/en/stable/index.html

--- a/docs/source/about/roadmap.rst
+++ b/docs/source/about/roadmap.rst
@@ -1,0 +1,28 @@
+.. _roadmap:
+
+=======
+Roadmap
+=======
+
+Welcome to ``predictably``'s roadmap.
+
+.. note::
+
+    The project is under active planning and development. We will continue to update
+    our roadmap as the project matures and we plan future work.
+
+Project Goals
+=============
+
+``predictably``'s goal is to help users predict *ably*.
+
+To accomplish this we plan to:
+
+- Provide an intuitive interface similar to `scikit-learn`_ and `sktime`_
+- Have best in class documentation that includes information on using the package,
+  as well as a broader understanding of the underlying algorithms.
+- Provide cross-language support so teams that work in different languages can easily
+  use the functionality.
+
+.. _scikit-learn: https://scikit-learn.org/stable/index.html
+.. _sktime: https://www.sktime.org/en/stable/index.html

--- a/docs/source/about/team.rst
+++ b/docs/source/about/team.rst
@@ -1,0 +1,50 @@
+.. _team:
+
+================
+Development Team
+================
+
+For more information about each of these roles, see ``predictably``'s
+:ref:`governance` document. A list of all contributors can be found under
+the `contributors <contributors.md>`_ section.
+
+Steering Committee
+==================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - GitHub ID
+   * - Ryan Kuhns
+     - :user:`rnkuhns`
+
+Code of Conduct Committee
+=========================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - GitHub ID
+   * - Ryan Kuhns
+     - :user:`rnkuhns`
+
+.. note::
+
+    The intent is to have a code of conduct committee separate from the steering
+    committee once the project community expands.
+
+Core Developers
+===============
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - GitHub ID
+   * - Ryan Kuhns
+     - :user:`rnkuhns`
+
+Former Core Developers (inactive)
+=================================

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -1,0 +1,64 @@
+.. _api_ref:
+
+=============
+API Reference
+=============
+
+Welcome to the API reference for ``predctiably``.
+
+The API reference provides a technical manual, describing the class and
+function interface provided by the package. See the :ref:`user_guide` for
+additional details.
+
+.. automodule:: predictably
+    :no-members:
+    :no-inherited-members:
+
+Configure ``predictably``
+=========================
+
+.. automodule:: predictably
+    :no-members:
+    :no-inherited-members:
+
+.. currentmodule:: predictably
+
+.. autosummary::
+    :toctree: api_reference/auto_generated/
+    :template: function.rst
+
+    get_config
+    get_default_config
+    set_config
+    reset_config
+    config_context
+
+.. _obj_validation:
+
+Object Validation and Comparison
+================================
+
+.. currentmodule:: predictably.validate
+
+.. autosummary::
+    :toctree: api_reference/auto_generated/
+    :template: function.rst
+
+    check_sequence
+    check_sequence_named_objects
+    check_type
+    is_sequence
+    is_sequence_named_objects
+
+Utils
+=====
+
+.. automodule:: predictably.utils
+    :no-members:
+    :no-inherited-members:
+
+.. currentmodule:: predictably.utils
+
+.. autosummary::
+    :toctree: api_reference/auto_generated/
+    :template: function.rst

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,3 @@
+.. _top_level_changelog:
+
+.. include:: user_documentation/changelog.rst

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -1,0 +1,49 @@
+.. _contrib_guide:
+
+============
+Get Involved
+============
+
+``predictably`` is a community-driven project, built by volunteers. Your help
+improving the package is and your help is extremely welcome. If you
+get stuck, please don't hesitate to chat with us or raise an issue.
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   contribute/how_to_contribute
+   contribute/development
+   contribute/team
+   contribute/code_of_conduct
+
+.. grid:: 1 2 2 2
+    :gutter: 3
+
+    .. grid-item-card:: How to Contribute
+        :text-align: left
+        :link: contribute/how_to_contribute
+        :link-type: doc
+
+        New to ``predictably``? Learn how you can contribute.
+
+    .. grid-item-card:: Development
+        :text-align: left
+        :link: contribute/development
+        :link-type: doc
+
+        Help develop ``predictably``.
+
+    .. grid-item-card:: Development Team
+        :text-align: left
+        :link: contribute/team
+        :link-type: doc
+
+        Meet ``predictably``'s core development team.
+
+    .. grid-item-card:: Code of Conduct
+        :text-align: left
+        :link: contribute/code_of_conduct
+        :link-type: doc
+
+        Understand our code of conduct.

--- a/docs/source/contribute/code_of_conduct.rst
+++ b/docs/source/contribute/code_of_conduct.rst
@@ -1,0 +1,19 @@
+.. _coc:
+
+===============
+Code of conduct
+===============
+
+The ``predictably`` project believes that everyone should be able to participate
+in our community without fear of harassment or discrimination. All contributors
+are expected to show respect and courtesy to other members of the community
+at all times.
+
+.. note::
+
+    ``predictably`` is a new project, and processes associated with the project's
+    Code of Conduct (including how to report incidents) and may change as the
+    project matures. However, ``predictably``'s Code of Conduct will remain
+    dedicated to promoting a community without harassment and discrimination. As
+    we formalize our policy, if you need to report a Code of Conduct incident,
+    reach out to predictably.ai@gmail.com.

--- a/docs/source/contribute/development.rst
+++ b/docs/source/contribute/development.rst
@@ -1,0 +1,48 @@
+===========
+Development
+===========
+
+.. note::
+
+    If you are new to ``predictably`` you may want to see how you can get
+    started :ref:`contributing <how_to_contrib>`.
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   development/developer_guide
+   development/reviewer_guide
+   development/contrib_roadmap
+   development/contrib_governance
+
+.. grid:: 1 2 2 2
+    :gutter: 3
+
+    .. grid-item-card:: Developer Guide
+        :text-align: left
+        :link: development/developer_guide
+        :link-type: doc
+
+        Learn our development conventions.
+
+    .. grid-item-card:: Reviewer Guide
+        :text-align: left
+        :link: development/reviewer_guide
+        :link-type: doc
+
+        How we review contributions.
+
+    .. grid-item-card:: Roadmap
+        :text-align: left
+        :link: development/contrib_roadmap
+        :link-type: doc
+
+        What's on our development horizon.
+
+    .. grid-item-card:: Governance
+        :text-align: left
+        :link: development/contrib_governance
+        :link-type: doc
+
+        Understand our code of conduct.

--- a/docs/source/contribute/development/contrib_governance.rst
+++ b/docs/source/contribute/development/contrib_governance.rst
@@ -1,0 +1,1 @@
+.. include:: ../../about/governance.rst

--- a/docs/source/contribute/development/contrib_roadmap.rst
+++ b/docs/source/contribute/development/contrib_roadmap.rst
@@ -1,0 +1,1 @@
+.. include:: ../../about/roadmap.rst

--- a/docs/source/contribute/development/developer_guide.rst
+++ b/docs/source/contribute/development/developer_guide.rst
@@ -1,0 +1,83 @@
+.. _dev_guide:
+
+===============
+Developer guide
+===============
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   developer_guide/dev_installation
+   developer_guide/git_workflow
+   developer_guide/ci
+   developer_guide/coding_standards
+   developer_guide/creating_docs
+   developer_guide/testing_framework
+   developer_guide/dependencies
+   developer_guide/enhancement_proposal
+   developer_guide/release_instructions
+
+.. grid:: 1 2 2 2
+    :gutter: 3
+
+    .. grid-item-card:: Installation
+        :text-align: left
+        :link: developer_guide/dev_installation
+        :link-type: doc
+
+        Install a development version of ``predictably``.
+
+    .. grid-item-card:: Git Workflow
+        :text-align: left
+        :link: developer_guide/git_workflow
+        :link-type: doc
+
+        Our Git and Github workflow.
+
+    .. grid-item-card:: Continuous Integration
+        :text-align: left
+        :link: developer_guide/ci
+        :link-type: doc
+
+        Continuous Integration.
+
+    .. grid-item-card:: Coding Standards
+        :text-align: left
+        :link: developer_guide/coding_standards
+        :link-type: doc
+
+        Our code requirements.
+
+    .. grid-item-card:: Documentation Standards
+        :text-align: left
+        :link: developer_guide/creating_docs
+        :link-type: doc
+
+        Our documentation requirements.
+
+    .. grid-item-card:: Testing Framework
+        :text-align: left
+        :link: developer_guide/testing_framework
+        :link-type: doc
+
+    .. grid-item-card:: Dependency Management
+        :text-align: left
+        :link: developer_guide/dependencies
+        :link-type: doc
+
+        How we manage dependencies
+
+    .. grid-item-card:: Proposing Enhancements
+        :text-align: left
+        :link: developer_guide/enhancement_proposal
+        :link-type: doc
+
+        How to propose a major change
+
+    .. grid-item-card:: Release Instructions
+        :text-align: left
+        :link: developer_guide/release_instructions
+        :link-type: doc
+
+        How to prepare a new release of ``predictably``

--- a/docs/source/contribute/development/developer_guide/ci.rst
+++ b/docs/source/contribute/development/developer_guide/ci.rst
@@ -1,0 +1,95 @@
+.. _ci:
+
+======================
+Continuous integration
+======================
+
+.. _Github Actions: https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions
+.. _precommit.ci: https://pre-commit.ci/
+
+``predictably`` uses `Github Actions`_ continuous integration (CI) services
+to ensure contributions meet the project's standards. See the sections below to
+see how the project automatically validates code quality, and builds and tests
+your changes.
+
+Code quality checks
+===================
+
+``predictably`` uses `pre-commit.ci <https://pre-commit.ci/>`_ to help maintain
+the project's :ref:`coding style <code_style>`, by automating the code quality
+checks spelled out in the .pre-commit-config.yaml in the project's root directory.
+These checks run automatically when you open a Pull Request or push a new commit
+to an existing Pull Request.
+
+When starting your development in your own local clone of the repository,
+you should use your command line tool to run :code:`pre-commit install`. This
+will setup pre-commit locally, and trigger the repositories pre-commit hooks
+to run prior committing your code locally.
+
+.. note::
+
+    The project also continues to make use of the deprecated
+    `pre-commit github action <https://github.com/pre-commit/action>`_, because
+    it makes it easy cancel other continuous integration steps
+    (including unit testing). This duplicates the code quality portion of the
+    CI routine, but enables the longer unit testing portion of the CI routine
+    to be cancelled whenever the code quality portion fails. A contribution
+    that enables Github Action workflows to be cancelled when
+    `pre-commit.ci <https://pre-commit.ci/>`_ fails, would be greatly appreciated.
+
+Unit testing
+============
+
+``predictably`` uses `pytest <https://docs.pytest.org/en/latest/>`_ for unit testing.
+To check if your code passes all tests locally, follow ``predictably``'s
+:ref:`development installation <dev_install>` instructions, which will install
+``pytest`` along with other development tools.
+
+With ``pytest`` installed, you can navigate to your local project's root directory
+and run:
+
+   .. code:: bash
+
+      pytest ./predictably
+
+or if you have `make <https://www.gnu.org/software/make/>`_ installed:
+
+   .. code:: bash
+
+      make test
+
+Infrastructure
+==============
+
+This section gives an overview of the infrastructure and continuous
+integration services ``predictably`` uses.
+
++---------------+-----------------------+-------------------------------------+
+| Platform      | Operation             | Project Configuration               |
++===============+=======================+=====================================+
+| `GitHub       | Build/test/           | `.github/workflows/ <https://gi     |
+| Actions`_     | distribute            | thub.com/predict-ably/predictably   |
+|               | on Linux, MacOS and   | /blob/main/.github/workflows/>`_    |
+|               | Windows               |                                     |
++---------------+-----------------------+-------------------------------------+
+| `pre-commit.ci| Automate code quality | `.pre-commit-config.yml             |
+| <https://     | validation            | <https://github.com/predict-ably    |
+| pre-commit.ci |                       | /predictably/blob/main/             |
+| />`_          |                       | .pre-commit-config.yaml>`_          |
++---------------+-----------------------+-------------------------------------+
+| `Read the     | Build/deploy          | `.readthedocs.yaml                  |
+| Docs <h       | documentation         | <https://github.com/predict-ably    |
+| ttps://readth |                       | /predictably/blob/main/             |
+| edocs.org>`__ |                       | .readthedocs.yaml>`_                |
++---------------+-----------------------+-------------------------------------+
+| `Codecov      | Test coverage         | `.codecov.yml <https://             |
+| <https://c    |                       | github.com/predict-ably/predictably |
+| odecov.io>`__ |                       | /blob/main/.codecov.yml>`_,         |
+|               |                       | `.coveragerc <https://              |
+|               |                       | github.com/predict-ably/predictably |
+|               |                       | /blob/main/.coveragerc>`_           |
++---------------+-----------------------+-------------------------------------+
+
+Additional scripts used for code quality, building, unit testing and
+distribution can be found in
+`build_tools/ <https://github.com/predict-ably/predictably/tree/main/build_tools>`_.

--- a/docs/source/contribute/development/developer_guide/coding_standards.rst
+++ b/docs/source/contribute/development/developer_guide/coding_standards.rst
@@ -1,0 +1,100 @@
+.. _code_standards:
+
+================
+Coding standards
+================
+
+.. _code_style:
+
+Coding style
+============
+
+``predictably`` follows standard Python code style conventions, including the
+`PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ coding guidelines.
+
+Code formatting and linting
+---------------------------
+
+``predictably`` uses a variety of tools to enforce code formatting conventions,
+including:
+
+* `black <https://black.readthedocs.io/en/stable/>`_ with configuration in
+  ``pyproject.toml``
+* `flake8 <https://flake8.pycqa.org/en/latest/>`__ with configurations in ``setup.cfg``
+* `isort <https://pycqa.github.io/isort/>`_ with configuration in ``pyproject.toml``
+* `pydocstyle <http://www.pydocstyle.org/en/stable/>`_ with configuration in
+  ``pyproject.toml``
+* `doc8 <https://github.com/PyCQA/doc8>`_ with configuration in ``pyproject.toml``
+* `bandit <https://bandit.readthedocs.io/en/latest/>`_ with configuration in
+  ``pyproject.toml``
+* ``numpydoc`` to enforce numpy `docstring standard
+  <https://numpydoc.readthedocs.io/en/latest/index.html>`_ ,
+* ``predictably`` specific conventions described in our
+  :ref:`documentation conventions <developer_guide_documentation>`.
+
+All of these conventions (except for predictably's specific documentation conventions
+are automatically run on Pull Requests using ``predictably``'s :ref:`ci` workflows.
+
+Setting up local code quality checks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When starting your development in your own local clone of
+the repository, you should enable ``pre-commit`` locally so the code formatting
+and linting tools are run prior to committing your code locally.
+
+Using pre-commit locally
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+To set up pre-commit, follow ``predictably``'s
+:ref:`development installation <dev_install>` instructions. Then navigate to
+the directory of your local clone of your forked repository and run
+:code:`pre-commit install`.
+
+Once installed, pre-commit will automatically run all ``predictably`` code
+quality checks on the files you changed whenever you make a new commit.
+
+You can find all of ``predictably``'s pre-commit configurations in
+`.pre-commit-config.yaml
+<https://github.com/predict-ably/predictably/blob/main/.pre-commit-config.yaml>`_.
+
+.. note::
+
+   To exclude a line of code from being checked by flake8, you can add a ``# noqa``
+   (no quality assurance) comment at the end of that line. However, this is
+   generally discouraged unless no other options for passing the code quality
+   checking are possible. In this case, provide a comment indicating the
+   reasoning above the line.
+
+   There are similar ways to exclude lines from the other code quality tools. But,
+   the same logic of discouraging this approach unless no other solution for
+   passing the code quality check exists.
+
+Integrating with your local developer IDE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Local developer IDEs often provide integration with with common code quality
+checks, but require you to set them up in the IDE specific ways.
+
+Visual Studio Code allows you to run code quality checks including
+``black``, ``flake8``, ``isort``, ``pydocstyle`` and/or ``numpydoc`` on save.
+However, they need to be activated individually in the VS Code preferences (
+or set in your local ``settings.json`` file). If you want to easily Install all
+the linters in your environment use the hint in the
+:ref:`development installation <dev_install>` instructions and run
+:code:`pip install --editable .[dev,test,linters]`.
+
+In Visual Studio Code, we also recommend to add ``"editor.ruler": [79, 88]``
+to your local ``settings.json`` to display the max line length.
+
+``predictably`` specific code formatting conventions
+----------------------------------------------------
+
+-  Check out our :ref:`glossary`.
+-  Avoid multiple statements on one line. Prefer a line return after a
+   control flow statement (``if``/``for``).
+-  Use absolute imports for references inside ``predictably``.
+-  Don’t use ``import *`` in the source code. It is considered
+   harmful by the official Python recommendations. It makes the code
+   harder to read as the origin of symbols is no longer explicitly
+   referenced, but most important, it prevents using a static analysis
+   tool like pyflakes to automatically find bugs.

--- a/docs/source/contribute/development/developer_guide/creating_docs.rst
+++ b/docs/source/contribute/development/developer_guide/creating_docs.rst
@@ -1,0 +1,218 @@
+.. _developer_guide_documentation:
+
+=======================
+Documentation standards
+=======================
+
+Providing instructive documentation is a key part of ``predictably``'s mission.
+To meet this, developers are expected to follow the project's documentation standards.
+
+These include:
+
+* Documenting code using NumPy-style docstrings
+* Following ``predictably``'s docstring convention for public code artifacts and modules
+* Adding new public functionality to the :ref:`api_ref`
+  and :ref:`user guide <user_guide>`
+* Including a description of the algorithm in the applicable portion of the
+  online text accompanying the package.
+
+More detailed information on ``predictably``'s documentation format is provided below.
+
+Docstring conventions
+=====================
+
+``predictably`` uses the numpydoc_ Sphinx extension and follows the
+`NumPy docstring format <https://numpydoc.readthedocs.io/en/latest/format.html>`_.
+
+To ensure docstrings meet expectations, ``predictably`` uses a combination of
+validations built into numpydoc_, pydocstyle_ pre-commit checks
+(set to the NumPy convention) and automated testing of docstring examples to
+ensure the code runs without error.
+
+However, the automated docstring validation in pydocstyle_ only covers basic
+formatting. Passing these tests is necessary to meet the ``predictably``
+docstring conventions, but is not sufficient for doing so.
+
+To ensure docstrings meet ``predictably``'s conventions, developers are expected
+to check their docstrings against numpydoc_ and ``predictably`` conventions and
+:ref:`reviewer's <reviewer_guide_doc>` are expected to also focus feedback on
+docstring quality.
+
+``predictably`` specific conventions
+------------------------------------
+
+Beyond basic NumPy docstring formatting conventions, developers should focus on:
+
+- Ensuring all parameters (classes, functions, methods) and attributes (classes)
+  are documented completely and consistently
+- Including links to the relevant topics in the :ref:`glossary` or
+  :ref:`user_guide` in the extended summary
+- Including an `Examples` section that demonstrates at least basic functionality
+  in all public code artifacts
+- Adding a `See Also` section that references related ``predictably`` code
+  artifacts as applicable
+- Including citations to relevant sources in a `References` section
+
+Accordingly, most public code artifacts in ``predictably``
+should generally include the following NumPy docstring convention sections:
+
+1. Summary
+2. Extended Summary
+3. Parameters
+4. Attributes (classes only)
+5. Returns or Yields (as applicable)
+6. Raises (as applicable)
+7. See Also (as applicable)
+8. Notes (as applicable)
+9. References (as applicable)
+10. Examples
+
+.. note::
+
+    In many cases a parameter, attribute, return, or error may be described
+    in the docstring of more than one class. To avoid confusion, developers
+    should make sure their docstrings are as similar as possible to existing
+    docstring descriptions of the the same parameter, attribute, return
+    or error. As applicable, this may mean copying the same docstring
+    section for the parameter, attribute, return or error.
+
+Summary and extended summary
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The summary should be a single line, followed by a (properly formatted)
+extended summary.
+
+The extended summary should include a user friendly explanation
+of the code artifacts functionality. The extended summary should also include
+links to relevant content in the :ref:`glossary` and :ref:`user guide <user_guide>`.
+
+If a "term" already exists in the glossary and the developer wants to link it
+directly they can use:
+
+.. code-block::
+
+    :term:`the glossary term`
+
+In other cases you'll want to use different phrasing but link to an existing
+glossary term, and the developer can use:
+
+.. code-block::
+
+    :term:`the link text <the glossary term>`
+
+In the event a term is not already in the glossary, developers should add the term
+to the :ref:`glossary` and include a reference (as shown above) to the added term.
+
+Likewise, a developer can link to a particular area of the user guide by including
+an explicit cross-reference and following the steps for referencing in Sphinx
+(see the helpful description on
+`Sphinx cross-references
+<https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html>`_
+posted by Read the Docs). Again developers are encouraged to add important content
+to the user guide and link to it if it does not already exist.
+
+See Also
+~~~~~~~~
+
+This section should reference other ``predictably`` code artifacts related to the code
+artifact being documented by the docstring. Developers should use judgement in
+determining related code artifacts.
+
+Notes
+~~~~~
+
+The notes section can include several types of information, including:
+
+- Mathematical details of a code object or other important implementation details
+  (using ..math or :math:`7+3` functionality)
+- Links to alternative implementations of the code artifact that are external to
+  ``predictably``
+- A summary of the aspects of an object's state that are updated by state
+  changing methods
+
+References
+~~~~~~~~~~
+
+Objects that implement functionality covered in a research article, book or
+other package, should include an applicable citation.
+
+This should be done by adding references into the references section of the docstring,
+and then typically linking to these in other parts of the docstring.
+
+The references you intend to link to within the docstring should follow a very specific
+format to ensure they render correctly. See the example below. Note the space between
+the ".." and opening bracket, the space after the closing bracket, and how all the
+lines after the first line are aligned immediately with the opening bracket.
+Additional references should be added in exactly the same way, but the number
+enclosed in the bracket should be incremented.
+
+.. code-block:: rst
+
+    .. [1] Some research article, link or other type of citation.
+       Long references wrap onto multiple lines, but you need to
+       indent them so they start aligned with opening bracket on first line.
+
+To link to the reference labeled as "[1]", you use "[1]\_". This only works within
+the same docstring. Sometimes this is not rendered correctly if the "[1]\_" link is
+preceded or followed by certain characters. If you run into this issue, try
+putting a space before and following the "[1]\_" link.
+
+To list a reference but not link it elsewhere in the docstring, you can leave
+out the ".. [1]" directive as shown below.
+
+.. code-block:: rst
+
+    Some research article, link or other type of citation.
+    Long references wrap onto multiple lines. If you are
+    not linking the reference you can leave off the ".. [1]".
+
+Examples
+~~~~~~~~
+
+Most code artifacts in ``predictably`` should include an examples section. At
+a minimum this should include a single example that illustrates basic functionality.
+
+
+The examples should use simple data (e.g. randomly generated data, etc)
+generated using a ``predictably`` dependency and wherever possible only depend
+on ``predictably`` or its core dependencies. Examples should also be designed to
+run quickly where possible. For quick running code artifacts, additional examples
+can be included to illustrate the affect of different parameter settings.
+
+.. _numpydoc: https://numpydoc.readthedocs.io/en/latest/index.html
+.. _pydocstyle: http://www.pydocstyle.org/en/stable/
+.. _sphinx: https://www.sphinx-doc.org/
+.. _readthedocs: https://readthedocs.org/projects/predictably/
+
+Documentation Build
+-------------------
+
+We use `sphinx`_ to build our documentation and `readthedocs`_ to host it.
+You can find our latest documentation `here <https://predictably.org>`_.
+
+The source files can be found
+in `docs/source/ <https://github.com/predict-ably/predictably/tree/main/docs/source>`_.
+The main configuration file for sphinx is
+`conf.py <https://github.com/predict-ably/predictably/blob/main/docs/source/conf.py>`_
+and the main page is
+`index.rst <https://github.com/predict-ably/predictably/blob/main/docs/source/index.rst>`_.
+To add new pages, you need to add a new ``.rst`` file and link to it from the
+applicable file in the existing documentation.
+
+To build the documentation locally, you need to install a few extra
+dependencies listed in
+`pyproject.toml <https://github.com/predict-ably/predictably/blob/main/pyproject.toml>`_.
+
+1. To install extra dependencies from the root directory of your local copy
+   of the forked repository, run:
+
+   .. code:: bash
+
+      pip install --editable .[docs]
+
+2. To build the website locally, from the root directory of your local copy, run:
+
+   .. code:: bash
+
+      cd docs
+      make html

--- a/docs/source/contribute/development/developer_guide/dependencies.rst
+++ b/docs/source/contribute/development/developer_guide/dependencies.rst
@@ -1,0 +1,92 @@
+.. _deps:
+
+============
+Dependencies
+============
+
+Types of dependencies
+=====================
+
+``predictably`` has three types of dependencies:
+
+* "core" dependencies that are required for ``predictably`` to install and run
+* "soft" dependencies that are required to import or use specific,
+  non-core functionality
+* "developer" dependencies are required for developing ``predictably`` but not
+  required of end-users (e.g., ``pre-commit``)
+* "test" dependencies are required for running ``predictably``'s unit tests
+
+Making it easy to install and use ``predictably`` in a variety of projects is
+on of ``predictably``'s goals. Therefore, we seeks to minimizing the number of
+dependencies needed to provide the proejct's functionality.
+
+Soft Dependencies
+=================
+
+A soft dependency is a dependency that is only required to import
+certain modules, but not necessary to use most of the package's functionality.
+Accordingly, soft dependencies are not automatically installed alongside
+``predictably``. If you want to install soft dependencies, you'll either need
+to do so manually or use follow the installation instructions and install
+the optional "[all_extras]" version of the package.
+
+Adding a soft dependency
+------------------------
+
+The project tries to keep its dependencies, including soft dependencies,
+minimized. Core developers will consider the pros and cons of any additional
+soft dependency when reviewing Pull Requests. In the event you need to add a new
+soft dependency or changing the version of an existing one,
+the following files need to be updated:
+
+*  `pyproject.toml <https://github.com/predict-ably/predictably/blob/main/pyproject.toml>`_,
+   adding the dependency or version bounds in the ``all_extras`` dependency set.
+   Following the `PEP 621 <https://www.python.org/dev/peps/pep-0621/>`_ convention,
+   all dependencies including build time dependencies and optional dependencies
+   are specified in this file.
+
+Informative warnings or error messages for missing soft dependencies should be raised,
+in a situation where a user would need them. This is handled through our
+``check_soft_dependencies`` `utility
+<https://github.com/predict-ably/predictably/blob/main/predictably/testing/utils/_dependencies.py>`_.
+
+There are specific conventions to add such warnings in ``BaseObject``-s.
+To add ``BaseObject`` with a soft dependency, ensure the following:
+
+*  imports of the soft dependency only happen inside the object
+   (e.g., a particular methods or in ``__init__`` after calls to
+   ``super(cls).__init__``).
+*  the ``python_dependencies`` tag of the ``BaseObject`` is populated with a ``str``,
+   or a ``list`` of ``str``, of import dependencies. Exceptions will automatically
+   raised when constructing the ``BaseObject`` in an environment without the
+   required packages.
+*  in the python module containing the ``BaseObject``, the
+   ``check_soft_dependencies`` utility is called at the top of the module,
+   with ``severity="warning"``. This will raise an informative warning message
+   at module import.
+*  In a case where the package import differs from the package name (i.e.,
+   ``import package_string`` is different from
+   ``pip install different-package-string``), the ``check_soft_dependencies``
+   utility should be used in ``__init__``. Both the warning and constructor call
+   should use the ``package_import_alias`` argument for this.
+*  If the soft dependencies require specific python versions, the ``python_version``
+   tag should also be populated, with a PEP 440 compliant version specification
+   ``str`` such as ``"<3.10"`` or ``">3.6,~=3.8"``.
+
+Core or developer dependencies
+==============================
+
+Core and developer dependencies can only be added by core developers after
+discussion in a core developer meeting or in the project's communication channels.
+
+When adding a new core dependency or changing the version of an existing one,
+the following files need to be updated:
+
+*  `pyproject.toml <https://github.com/predict-ably/predictably/blob/main/pyproject.toml>`_,
+   adding the dependency or version bounds in the ``dependencies`` dependency set.
+
+When adding a new developer dependency or changing the version of an existing one,
+the following files need to be updated:
+
+*  `pyproject.toml <https://github.com/predict-ably/predictably/blob/main/pyproject.toml>`_,
+   adding the dependency or version bounds in the ``dev`` dependency set.

--- a/docs/source/contribute/development/developer_guide/dev_installation.rst
+++ b/docs/source/contribute/development/developer_guide/dev_installation.rst
@@ -1,0 +1,7 @@
+==============================
+Development Installation Guide
+==============================
+
+If you plan on contributing to ``predictably`` you'll want a development installation
+of ``predictably``. Follow the :ref:`development installation <dev_install>`
+instructions.

--- a/docs/source/contribute/development/developer_guide/enhancement_proposal.rst
+++ b/docs/source/contribute/development/developer_guide/enhancement_proposal.rst
@@ -1,0 +1,46 @@
+.. _bep:
+
+=====================
+Enhancement Proposals
+=====================
+
+Description
+===========
+
+A ``predictably`` enhancement proposal (PREP) is a software design document
+providing information to the ``predictably`` community.
+The proposal should provide a rationale and concise technical specification of
+the proposed design.
+
+We intend PREPs to be the primary mechanisms for proposing major changes,
+for collecting community input on an issue, and for documenting the design
+decisions that have gone into ``predictably``.
+
+Smaller changes will be discussed and implemented directly on issues and pull requests.
+
+Existing PREPs
+==============
+
+You can find existing PREPs in the `enhancement_proposals folder`_ in the
+package's root directory.
+
+.. _enhancement_proposals folder: https://github.com/predict-ably/predictably/tree/main/enhancement_proposals
+
+Submitting a PREP
+=================
+
+To create a new PREP, please copy and use sktime's `template`_ (update any
+references to sktime when drafting your PREP) and open a pull request on
+the ``predctably`` repository.
+
+.. _template: https://github.com/sktime/enhancement-proposals/blob/main/TEMPLATE.md
+
+It is highly recommended that a single PREP contains a single key proposal or new idea.
+The more focused the proposal, the more successful it tends to be.
+If in doubt, split your PREP into several well-focused ones.
+
+A PREP should be a consolidated document, including:
+
+* a concise problem statement,
+* a clear description of the proposed solution,
+* a comparison with alternative solutions.

--- a/docs/source/contribute/development/developer_guide/git_workflow.rst
+++ b/docs/source/contribute/development/developer_guide/git_workflow.rst
@@ -1,0 +1,106 @@
+.. _git_workflow:
+
+Git and GitHub workflow
+=======================
+
+.. note::
+
+   If your not familiar with ``git`` you may want to start by reviewing
+   `Git's documentation <https://git-scm.com/doc>`_ and then trying
+   out the workflow. If you get stuck, chat with us on
+   `Slack <https://join.slack.com/t/sktime-group/shared_invite/zt-1cghagwee-sqLJ~eHWGYgzWbqUX937ig>`_.
+
+The preferred workflow for contributing to ``predictably``'s repository is to
+fork the `main repository <https://github.com/predict-ably/predictably>`_ on GitHub,
+clone your fork locally and create a development installation, and then create
+a new feature branch for your development.
+
+1.  Fork the `project
+    repository <https://github.com/predict-ably/predictably>`_ by
+    clicking on the 'Fork' button near the top right of the page. This
+    creates a copy of the code under your GitHub user account. For more
+    details on how to fork a repository see `this
+    guide <https://help.github.com/articles/fork-a-repo/>`_.
+
+2.  Follow ``predict-ably/predictably``'s :ref:`development installation <dev_install>`
+    instructions.
+
+3.  Configure and link the remote for your fork to the upstream
+    repository:
+
+    .. code:: bash
+
+       git remote -v
+       git remote add upstream https://github.com/predict-ably/predictably.git
+
+4.  Verify the new upstream repository you've specified for your fork:
+
+    .. code:: bash
+
+       git remote -v
+       > origin    https://github.com/<username>/predictably.git (fetch)
+       > origin    https://github.com/<username>/predictably.git (push)
+       > upstream  https://github.com/predict-ably/predictably.git (fetch)
+       > upstream  https://github.com/predict-ably/predictably.git (push)
+
+5.  `Sync
+    <https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork>`_
+    the ``main`` branch of your fork with the upstream repository:
+
+    .. code:: bash
+
+       git fetch upstream
+       git checkout main
+       git merge upstream/main
+
+    .. hint::
+
+        You can use these same instructions to sync another branch by replacing
+        the "main" branch with the name of the other branch you want to sync.
+
+6.  Create a new ``feature`` branch from the ``main`` branch to hold
+    your changes:
+
+    .. code:: bash
+
+       git checkout main
+       git checkout -b <name-of-feature-branch>
+
+    .. note::
+
+        Always use a ``feature`` branch. It's good practice to never work on
+        the ``main`` branch. Name the ``feature`` branch after your contribution.
+
+7.  Develop your contribution on your feature branch. Add changed files
+    using ``git add`` and then ``git commit`` files to record your
+    changes in Git:
+
+    .. code:: bash
+
+       git add <modified_files>
+       git commit
+
+8.  When finished, push the changes to your GitHub account with:
+
+    .. code:: bash
+
+       git push --set-upstream origin my-feature-branch
+
+9.  Follow
+    `these instructions
+    <https://help.github.com/articles/creating-a-pull-request-from-a-fork>`_
+    to create a pull request from your fork. If your work is still work in progress,
+    make sure to open a draft pull request.
+
+    .. note::
+
+        We recommend opening a pull request early, so that other contributors
+        become aware of your work and can give you feedback early on.
+
+10. To add more changes related to this feature, simply repeat steps 7 - 8.
+
+    .. note::
+
+        Pull requests are updated automatically if you push new changes to the
+        same branch. This will trigger ``predictably``'s
+        :ref:`continuous integration <ci>` routine to re-run automatically.

--- a/docs/source/contribute/development/developer_guide/release_instructions.rst
+++ b/docs/source/contribute/development/developer_guide/release_instructions.rst
@@ -1,0 +1,210 @@
+.. _release:
+
+==================
+Release Management
+==================
+
+This section provides detailed instructions used to release a new version
+of ``predictably``.
+
+This task is carried out by core developers with write access to the ``predictably``
+repository and designated as release managers by the
+:ref:`Steering Committee <steering_committee>`.
+
+Summary of release process
+==========================
+
+The release process includes, in sequence:
+
+* :ref:`prepare for an upcoming release <cycle_process>`
+* :ref:`get the release ready <release_version_prep>`
+* :ref:`release on PyPi <pypi_release>`
+* :ref:`release on conda <conda_release>`
+* troubeleshooting and accident remediation, if applicable (see troubeleshooting
+  tips in each of the prior sections)
+
+Details follow below.
+
+.. _cycle_process:
+
+Release preparation cycle
+-------------------------
+
+``predictably`` aims for a release every month, typically coinciding with the start of
+the month. To ensure releases go smoothly, the following steps are taken leading
+up to each release:
+
+1. 1 week before release date, update the release project board and alert
+   project contributors of upcoming release on slack.
+2. For major releases or substantial features, optionally extend the release cycle,
+   if needed, so that the changes can be completed and incorporated in the release.
+   If a release will be delayed, notify project contributors on slack.
+3. All changes to the main branch of the repository are frozen 1 day prior to the
+   release. At this point only the release managers (for this release) should
+   merge any pull requests. Remind core developers of the timing of the feature
+   freeze on slack when announcing the upcoming release date. Remind core developers
+   of the feature freeze again 1 day prior to its start. Make sure to keep
+   core developers in the loop if any delays or extensions to the feature freeze arise.
+4. If "must have" pull requests are not merged by the planned release date, the
+   release manager should coordinate with the Steering Committee to either delay
+   the release date and extend freeze period, or move the pull requests target
+   completion to a later release.
+
+.. _release_version_prep:
+
+Preparing the release version
+-----------------------------
+
+The release process is as follows, on high-level:
+
+1. Ensure deprecation actions are carried out. Deprecation actions for a version
+   should be marked by "version number" annotated comments in the code. E.g.,
+   for the release 0.2.0, search for the string 0.2.0 in the code and carry out
+   the described deprecation actions. Collect list of deprecation actions in an issue,
+   as they will have to go in the release notes. Deprecation actions should be merged
+   only by release managers.
+
+2. Create a "release" Pull Request from a branch following the naming pattern
+   ``release-vm.x.y``, where "m", "x" and "y" are placeholders for the major,
+   minor, and patch version numbers. This pull request should:
+
+   - Update the package version numbers
+     (see :ref:`version number locations <version_number_locs>`)
+   - Add complete release notes
+     (see :ref:`generating release notes <generate_release_notes>`)
+   - Update the ``switcher.json`` file located at ``./docs/source/_static/``
+     relative to the project's root. This involves creating a new entry for the
+     prior release (which was the "stable" doc release previously) and rename
+     the stable release to reference the updated version number.
+
+3. The PR and release notes should be reviewed by the other core developers,
+   then merged once tests pass.
+
+4. Create a GitHub draft release with a new tag following the syntax
+   v[MAJOR].[MINOR].[PATCH]. E.g., the string ``v0.12.0`` for version 0.12.0.
+   The GitHub release notes should contain only "new contributors" and
+   "all contributors" section, and otherwise link to the release notes in the
+   changelog, following the pattern of current GitHub release notes.
+
+.. _pypi_release:
+
+``pypi`` release and release validation
+---------------------------------------
+
+5. Publish the GitHub draft release. Creation of the new tag will trigger the
+   ``pypi`` release CI/CD.
+
+6. Wait for the ``pypi`` release CI/CD to finish. If tests fail due to sporadic
+   failures unrelated to the content being released, restart the CI/CD routine.
+   If tests fail genuinely, something went wrong in the above steps, investigate,
+   fix, and repeat. Common possibilities are core devs not respecting the feature
+   freeze period, new releases of dependencies that happen in the period between
+   release PR and release.
+
+7. Once release CI/CD has passed, check the ``predictably`` version on ``pypi``,
+   this should be the new version. It should be checked that all wheels have been
+   uploaded, `here <https://pypi.org/simple/predictably/>`__. As a test, one install
+   of ``predictably`` in a new ``python`` environment should be carried out
+   according to the install instructions (choose an arbitrary version/OS).
+   If the install does not succeed or wheels have not been uploaded, urgent
+   action to diagnose and remedy must be taken. All core developers should be
+   informed of the situation through the contact all functionality in the
+   core developer channel on slack. In the most common case, the install
+   instructions need to be updated. If wheel upload has failed, the tag in Step 5
+   needs to be deleted and recreated. The tag can be deleted using the
+   ``git`` command ``git push --delete origin tagname`` from a local repo.
+
+.. _conda_release:
+
+``conda`` release and release validation
+----------------------------------------
+
+8. If the release on ``pypi`` has succeeded, there should be an automated
+   release PR created against the ``predictably`` conda-forge repo:
+   https://github.com/conda-forge/predictably-feedstock.
+
+  .. note:: Manual creation of release pull request
+     In cases where the release PR is not created automatically it can be created
+     and submitted manually. For general guidelines related to maintaining conda
+     feedstcok packages see
+     `conda-forge package <https://conda-forge.org/docs/maintainer/updating_pkgs.html>`_.
+
+     After forking and cloning the repo, edit the ``meta.yml`` file by:
+
+     - incrementing the version in the line that contains ``{% set version = "M.X.Y" %}``
+     - pasting the sha256 sum of the source archive from github in the
+       ``source/sha256`` section
+
+    Once finished, submit the PR and ask for review.
+
+9. The conda release PR needs to be reviewed and in dependencies should be
+   checked against any changes in the main ``predictably`` repo. In case the
+   dependencies (or python version support) have changes, the ``meta.yml`` file
+   in the conda recipe needs to be updated to reflect those changes.
+
+10. Once reviewed, the conda release PR should merged, and it will automatically
+    trigger a release of the conda package.
+
+11. After 1h, it should be checked whether the package has been released on conda.
+    Once the package is available on ``conda``, a test install should be carried out
+    to validate the release. Should either of these fail, alert the core developers
+    and follow an urgent action plan in line with the description in step 7.
+
+.. _version_number_locs:
+
+Release Pull Request Tips
+=========================
+
+When creating the release Pull Request it is important to update all the version
+numbers and the release notes documentation. A full list of things that need to be
+updated in every release Pull Request is contained below. It is possible a given
+release could require more items to be updated.
+
+Version number locations
+------------------------
+
+Version numbers need to be updated in:
+
+* root ``__init__.py``
+* ``README.md``
+* ``pyproject.toml``
+
+Add new choice to "switcher"
+----------------------------
+
+A new entry has to be added to the "switcher" that controls the drop down that
+lets users see the documentation for different versions of the package. This is
+done using the file ``predictably/docs/source/_static/switcher.json``.
+
+- Copy the entry for the current "stable" version and add it to the list (in
+  release order).
+- Update the name of the copied entry to remove the "(stable)" terminology.
+- Update the original "stable" version to update the version number in the
+  name and the url.
+
+Note that the "switcher" functionality doesn't work in the version of the docs that
+is built during a Pull Request, so be sure to double-check you provided the right
+version numbers.
+
+.. _generate_release_notes:
+
+Generating release notes
+------------------------
+
+Release notes can be generated using the ``build_tools.changelog.py`` script,
+and should be placed at the top of the ``changelog.rst``. Generally, release notes
+should follow the general pattern of previous release notes, with sections:
+
+* highlights
+* dependency changes, if any
+* deprecations and removals, if any. In PATCH versions, there are no deprecation
+  actions, but there can be new deprecations.
+  Deprecation action usually happen with the MINOR release cycle.
+* core interface changes, if any. This means, changes to the base class interfaces.
+  Only MINOR or MAJOR releases should have core interface changes that are not
+  downwards compatible.
+* enhancements, by module/area
+* bugfixes
+* documentation
+* maintenance
+* all contributor credits

--- a/docs/source/contribute/development/developer_guide/testing_framework.rst
+++ b/docs/source/contribute/development/developer_guide/testing_framework.rst
@@ -1,0 +1,42 @@
+=================
+Testing Framework
+=================
+
+.. note::
+
+    This page will explain ``predictably``'s testing framework with an emphasis on
+    how contributors should use the framework to test their contributions. It is
+    a work in progress.
+
+``predictably`` uses ``pytest`` to verify code is working as expected.
+This page gives an overview of the tests, an introduction on adding new tests,
+and how to extend the testing framework.
+
+.. warning::
+
+  This page is under construction. We plan to add more tests and increased
+  documentation on the testing framework in an upcoming release.
+
+Test module architecture
+========================
+
+``predictably`` uses a tiered approach to test its functionality:
+
+- *package level* tests are located in ``predictably/tests/`` and are meant to
+  test functionality used throughout the package.
+
+- *module level* tests are included in the ``tests`` folders in each module and
+   are focused on verifying an individual models functionality.
+
+- *low level* tests in the ``tests`` folders in each module are used to verify the
+  functionality of individual code artifacts
+
+Module conventions are as follows:
+
+* Each module contains a ``tests`` folder that contains tests specific to that module.
+    * Sub-modules may also contain ``tests`` folders.
+    * *module* tests focused on testing a specific class interface should contain a file
+      ``test_all_[name_of_class].py``
+* ``tests`` folders may contain ``_config.py`` files to collect test
+  configuration settings for that modules.
+* *module* and *low* level tests should not repeat tests performed at a higher level.

--- a/docs/source/contribute/development/reviewer_guide.rst
+++ b/docs/source/contribute/development/reviewer_guide.rst
@@ -1,0 +1,70 @@
+.. _reviewer_guide:
+.. _rev_guide:
+
+==============
+Reviewer Guide
+==============
+
+Pull Request reviewers play an important role in ``predictably``'s development. On
+the ``predictably`` project our review takes three main forms:
+
+- Triage
+- Code Review
+- Documentation Review
+
+See the details on each level of review below.
+
+.. warning::
+
+    The reviewer guide is under development. If you have suggestions, open an
+    issue or Pull Request.
+
+
+Triage
+======
+
+* Assign relevant labels
+* Assign to relevant project board
+* Title: Is it using the 3-letter codes? Is it understandable?
+* Description: Is it understandable? Any related issues/PRs?
+* CI checks: approval for first-time contributors, any help needed with
+  code/doc quality checks?
+* Merge conflicts
+
+Code Review
+===========
+
+* Unit testing:
+
+    - Are the code changes tested?
+    - Are the tests understandable?
+    - Are all changes covered by tests? We usually aim for a test coverage of
+      at least 90% (but preferably 100% coverage on new code).
+    - Code coverage will be reported as part of the automated CI checks on
+      GitHub and on the
+      `Codecov website <https://app.codecov.io/gh/predict-ably/predictably>`_.
+
+* Test changes locally: Does everything work as expected?
+* Deprecation warnings:
+
+    - Has the public API changed?
+    - Have deprecation warnings been added before making the changes?
+
+.. _reviewer_guide_doc:
+
+Documentation Review
+====================
+
+* Are the docstrings complete and understandable to users?
+* Do they follow the NumPy format and ``predictably`` conventions?
+* If the same parameter, attribute, return object or error is included elsewhere
+  in ``predictably`` are the docstring descriptions as similar as possible?
+* Does the online documentation render correctly with the changes?
+* Do the docstrings contain links to the relevant topics in the
+  :ref:`glossary` or :ref:`user_guide`?
+
+.. note::
+
+    If a Pull Request does not meet ``predictably``'s
+    :ref:`documentation guide <developer_guide_documentation>` a reviewer should
+    require the documentation be updated prior to approving the Pull Request.

--- a/docs/source/contribute/how_to_contribute.rst
+++ b/docs/source/contribute/how_to_contribute.rst
@@ -1,0 +1,28 @@
+.. _how_to_contrib:
+
+=================
+How to contribute
+=================
+
+You can contribute to ``predictably`` in a variety of ways. This includes
+contributing code (see our :ref:`roadmap <roadmap>` for information our planned
+development), but we value all kinds of contributions. Helping improve
+the package's documentation or providing feedback and weighing in on existing
+issues on `github <https://github.com/predict-ably/predictably/issues>`_ are
+especially welcome.
+
+The ``predictably`` team is also happy to support new contributors and
+individuals looking to develop their skills.
+
+If you want to get started contributing, we recommend:
+
+- Say hello on `Slack`_
+- Use our :ref:`developer guide <dev_guide>` to setup a contributing environment
+- Pick a good first `issue <https://github.com/predict-ably/predictably/issues>`_
+  to work on that will let you get familiar with our contributing process
+
+Once your first Pull Request is merged you may decide to continue contributing
+regularly. Talk with the development team on `Slack`_ about your interests and
+how you can best contribute to the project.
+
+.. _Slack: https://join.slack.com/t/predict-ably/shared_invite/zt-21ezi33ip-WGJCUBCWc5yVrr6FOsARaw  # noqa

--- a/docs/source/contribute/team.rst
+++ b/docs/source/contribute/team.rst
@@ -1,0 +1,3 @@
+.. _contrib_team:
+
+.. include:: ../about/team.rst

--- a/docs/source/get_started.rst
+++ b/docs/source/get_started.rst
@@ -1,0 +1,73 @@
+.. _getting_started:
+
+===========
+Get Started
+===========
+
+The following information is designed to get users up and running with
+``predictably`` quickly. For more detailed information, see the links in each
+of the subsections.
+
+Installation
+============
+
+``predictably`` currently supports:
+
+* environments with python version 3.7, 3.8, 3.9, 3.10 or 3.11
+* operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
+* installation via ``PyPi``
+
+Users can choose whether to install the ``predictably`` with its standard dependencies
+or alternatively to install ``predictably`` with all its dependencies using the
+code snippets below.
+
+.. tab-set::
+
+    .. tab-item:: PyPi
+
+        .. code-block:: bash
+
+           pip install predictably
+
+    .. tab-item:: PyPi (all dependencies)
+
+        .. code-block:: bash
+
+           pip install predictably[all_extras]
+
+    .. tab-item:: Conda
+
+        .. note::
+
+            We are still working on creating releases of ``predictably`` on ``conda``.
+            If you would like to help, please open a pull request.
+
+    .. tab-item:: Conda (all dependencies)
+
+        .. note::
+
+            We are still working on creating releases of ``predictably`` on ``conda``.
+            If you would like to help, please open a pull request.
+
+For additional details see our :ref:`full installation guide <full_install>`.
+
+
+Key Concepts
+============
+
+.. warning::
+
+    The ``predictably`` package is new and this part of the documentation is still
+    being developed as the package works toward maturity.
+
+
+
+Quickstart
+==========
+The code snippets below are designed to introduce ``predictably``'s
+functionality. For more detailed information see the :ref:`tutorials`,
+:ref:`user_guide` and :ref:`api_ref` in ``predictably``'s
+:ref:`user_documentation`.
+
+.. _scikit-learn: https://scikit-learn.org/stable/index.html
+.. _sktime: https://www.sktime.org/en/stable/index.html

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,20 +1,66 @@
-.. predictably documentation master file, created by
-   sphinx-quickstart on Fri Aug 11 17:32:37 2023.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+.. _home:
 
-Welcome to predictably's documentation!
-=======================================
+======================
+Welcome to predictably
+======================
+
+``predictably`` seeks to provide an intuitive,
+well documented interface for a variety of statistical and machine learning problems.
 
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+   :maxdepth: 1
+   :hidden:
 
+   get_started
+   users
+   api_reference
+   contribute
+   about
+   changelog
 
+From here, you can navigate to:
 
-Indices and tables
-==================
+.. grid:: 1 2 2 2
+    :gutter: 3
 
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+    .. grid-item-card:: Get Started
+        :text-align: left
+        :link: get_started
+        :link-type: doc
+
+        Get started with ``predictably`` quickly.
+
+    .. grid-item-card:: User Documentation
+        :text-align: left
+        :link: users
+        :link-type: doc
+
+        Find user documentation.
+
+    .. grid-item-card:: API Reference
+        :text-align: left
+        :link: api_reference
+        :link-type: doc
+
+        Understand ``predictably``'s API.
+
+    .. grid-item-card:: Get Involved
+        :text-align: left
+        :link: contribute
+        :link-type: doc
+
+        Find out how you can contribute.
+
+    .. grid-item-card:: About
+        :text-align: left
+        :link: about
+        :link-type: doc
+
+        Learn more about ``predictably``.
+
+    .. grid-item-card:: Release Notes
+        :text-align: left
+        :link: changelog
+        :link-type: doc
+
+        See what's new in our latest release.

--- a/docs/source/user_documentation/changelog.rst
+++ b/docs/source/user_documentation/changelog.rst
@@ -1,0 +1,23 @@
+=========
+Changelog
+=========
+
+All notable changes to this project beginning with version 0.3.0 will be
+documented in this file. The format is based on
+`Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_ and we adhere
+to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_. The source
+code for all `releases <https://github.com/sktime/baseobject/releases>`_
+is available on GitHub.
+
+You can also subscribe to ``predictably``'s
+`PyPi release <https://libraries.io/pypi/predictably>`_.
+
+For planned changes and upcoming releases, see our :ref:`roadmap`.
+
+[0.3.0] - 2023-11-07
+====================
+
+Highlights
+----------
+
+- Initial release of the updated ``predictably`` package!

--- a/docs/source/user_documentation/glossary.rst
+++ b/docs/source/user_documentation/glossary.rst
@@ -1,0 +1,37 @@
+.. _glossary:
+
+========================
+Glossary of Common Terms
+========================
+
+The glossary below defines common terms and API elements used throughout
+``predictably``.
+
+.. note::
+
+    The glossary is under development. Important terms are still missing.
+    Please create a pull request if you want to add one.
+
+
+.. glossary::
+    :sorted:
+
+    Framework
+        A collection of related and reusable software design templates that
+        practitioners can copy and fill in. Frameworks emphasize design reuse.
+        They capture common software design decisions within a given application domain
+        and distill them into reusable design templates. This reduces the design
+        decision they must take, allowing them to focus on application specifics.
+        Not only can practitioners write software faster as a result, but
+        applications will have a similar structure. Frameworks often offer
+        additional functionality like :term:`toolboxes <toolbox>`. Compare with
+        :term:`toolbox` and :term:`application`.
+
+    Toolbox
+        A collection of related and reusable functionality that practitioners
+        can import to write applications. Toolboxes emphasize code reuse.
+        Compare with :term:`framework` and :term:`application`.
+
+    Application
+        A single-purpose piece of code that practitioners write to solve a
+        particular applied problem. Compare with :term:`toolbox` and :term:`framework`.

--- a/docs/source/user_documentation/installation.rst
+++ b/docs/source/user_documentation/installation.rst
@@ -1,0 +1,203 @@
+.. _full_install:
+
+============
+Installation
+============
+
+``predictably`` currently supports:
+
+* environments with python version 3.7, 3.8, 3.9, 3.10 or 3.11
+* operating systems Mac OS X, Unix-like OS, Windows 8.1 and higher
+
+Checkout the full list of pre-compiled wheels on
+`PyPI <https://pypi.org/simple/predictably/>`_.
+
+Release versions
+================
+
+Most users will be interested in installing a released version of ``predictably``
+using one of the approaches outlined below. For common installation issues,
+see the `troubleshooting release installations`_ section.
+
+Installing ``predictably``
+--------------------------
+
+``predictably`` releases are available via PyPI and can be installed via ``pip``.
+Users can choose whether to install the ``predictably`` with its standard dependencies
+or alternatively to install ``predictably`` with all its dependencies using the
+code snippets below.
+
+.. tab-set::
+
+    .. tab-item:: PyPi
+
+        .. code-block:: bash
+
+           pip install predictably
+
+    .. tab-item:: PyPi (all dependencies)
+
+        .. code-block:: bash
+
+           pip install predictably[all_extras]
+
+    .. tab-item:: Conda
+
+        .. note::
+
+            We are still working on creating releases of ``predictably`` on ``conda``.
+            If you would like to help, please open a pull request.
+
+    .. tab-item:: Conda (all dependencies)
+
+        .. note::
+
+            We are still working on creating releases of ``predictably`` on ``conda``.
+            If you would like to help, please open a pull request.
+
+
+Troubleshooting release installations
+-------------------------------------
+
+Missing soft dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Users may run into problems, when they install the core version of ``predictably``,
+but attempt to use functionality that requires soft dependencies to be installed.
+To resolve this, install the missing package, or install ``predictably``
+with maximum dependencies (see above).
+
+.. _dev_install:
+
+Development versions
+====================
+
+To install the latest development version of ``predictably``, the sequence
+of steps is as follows:
+
+
+1. Clone the ``predictably`` `Github repository`_
+2. Create a new virtual environment via ``conda`` and activate it.
+3. Use ``pip`` to build ``predictably`` from source and install development dependencies
+
+
+Detail instructions for each step is provided below.
+
+Step 1 - Clone Github repository
+--------------------------------
+
+The ``predictably`` `Github repository`_ should be cloned to a local directory.
+
+To install the latest version using the ``git`` command line, use the following steps:
+
+1. Use your command line tool to navigate to the directory where you want to clone
+   ``predictably``
+2. Clone the repository: :code:`git clone https://github.com/predict-ably/predictably.git`
+3. Move into the root directory of the package's local clone: :code:`cd predictably`
+4. Make sure you are on the main branch: :code:`git checkout main`
+5. Make sure your local version is up-to-date: :code:`git pull`
+
+See Github's `repository clone documentation`_
+for additional details.
+
+.. hint::
+
+    If you want to checkout an earlier version of ``predictably`` you can use the
+    following git command line after cloning to run: :code:`git checkout <VERSION>`
+
+    Where ``<VERSION>`` is a valid version string that can be found by inspecting the
+    repository's ``git`` tags, by running ``git tag``.
+
+    You can also download a specific release version from the Github repository's
+    zip archive of `releases <https://github.com/predict-ably/predictably/releases>`_.
+
+Step 2 - Create a new virtual environment
+-----------------------------------------
+
+Setting a new virtual environment before building ``predictably`` ensures that
+conflicting package versions are not installed in the same environment.
+You can choose your favorite env manager for this but we're showing the
+steps to create one using ``conda``:
+
+1. Use your command line tool to first confirm ``conda`` is present on your
+   system: :code:`conda --version`
+2. Create a new virtual environment named ``predictably-dev`` with python version
+   ``3.9`` or greater (:code:`conda create -n predictably-dev python=3.9`)
+3. Activate this newly created environment: :code:`conda activate predictably-dev`
+
+Step 3 - Build ``predictably`` from source
+------------------------------------------
+
+When contributing to the project, you will want to install ``predictably`` locally,
+along with additional dependencies used when developing the package.
+
+You can opt for a static install of ``predictably`` from your local source, but
+if you plan to contribute to the project you may be better served by
+installing ``predictably`` in `editable mode`_ so that the the package updates each
+time the local source code is changed.
+
+Either way, including the "[dev,test]" modifier, makes sure that the additional
+developer dependencies and test dependencies specified in the ``predictably``
+pyproject.toml file are also installed.
+
+To use either approach:
+
+1. Use your command line tool to navigate to the root directory of your local
+   copy of the ``predictably`` project
+2. Copy the code snippet below that corresponds to the installation approach you
+   would like to use
+3. Paste the copied code snippet in your command line tool and run it
+
+.. tab-set::
+
+    .. tab-item:: Static installation
+
+        .. code-block:: bash
+
+           pip install .[dev,test]
+
+    .. tab-item:: Install in editable mode
+
+        .. code-block:: bash
+
+           pip install --editable .[dev,test]
+
+.. hint::
+
+    In either the static or editable installation, the ``.`` may be replaced
+    with a full or relative path to your local clone's root directory.
+
+.. hint::
+
+    Using the "[dev]" modifier installs developer dependencies, including
+    ``pre-commit`` and other tools you'll want to use when developing ``predictably``.
+    In most cases, you'll let ``pre-commit`` manage installation environments
+    for your linting tools. However, some integrated development environments
+    (for example, VS Code) will automatically apply linters (including
+    reformatting) on save. In some versions this requires the linters to be
+    installed directly in your development environment. If you want to easily
+    install all the linters used by ``predictably`` in your development environment use
+    :code:`pip install .[dev,test,linters]`
+    or :code:`pip install --editable .[dev,test,linters]` instead.
+
+Building binary packages and installers
+=======================================
+
+The ``.whl`` package and ``.exe`` installers can be built with:
+
+.. code-block:: bash
+
+    pip install wheel
+    python setup.py bdist_wheel
+
+The resulting packages are generated in the ``dist/`` folder.
+
+References
+----------
+
+The installation instruction are adapted from sktime's
+`installation instructions <https://www.sktime.org/en/stable/installation.html>`_.
+
+.. _Github repository: https://github.com/predict-ably/predictably
+.. _repository clone documentation: https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository
+.. _editable mode: https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs

--- a/docs/source/user_documentation/related_software.rst
+++ b/docs/source/user_documentation/related_software.rst
@@ -1,0 +1,13 @@
+.. _related_software:
+
+================
+Related Software
+================
+
+The Python ecosystem containsa variety of packages designed to make it easier
+to work with classes. The following list is by no means exhaustive.
+If we missed anything, feel free to open a Pull Request.
+
+.. note::
+
+    The related software section is under development.

--- a/docs/source/user_documentation/tutorials.rst
+++ b/docs/source/user_documentation/tutorials.rst
@@ -1,0 +1,11 @@
+.. _tutorials:
+
+=========
+Tutorials
+=========
+
+.. note::
+
+    We plan to add tutorials walk through examples of how you can use
+    ``predictably`` in a future release. Feel free to open a Pull Request
+    if you would like to add any tutorials in the meantime.

--- a/docs/source/user_documentation/user_guide.rst
+++ b/docs/source/user_documentation/user_guide.rst
@@ -1,0 +1,47 @@
+
+.. _user_guide:
+
+==========
+User Guide
+==========
+
+Welcome to ``predictably``'s user guide!
+
+The purpose of the user guide is to provide further explanations and context
+on how you can use ``predictably``'s functionality. Future documentation will also
+provide a companion explanation of the algorithms and techniques available in
+the package.
+
+If your just looking for a technical specification of the functionality
+that ``predictably`` provides, see the :ref:`api_ref`.
+
+.. note::
+
+    The user guide is under development. We have created a basic
+    structure and are looking for contributions to develop the user guide
+    further.
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   user_guide/overview
+   user_guide/configuration
+
+
+.. grid:: 1 2 2 2
+    :gutter: 3
+
+    .. grid-item-card:: Overview
+        :text-align: left
+        :link: user_guide/overview
+        :link-type: doc
+
+        Get an overview of ``predictably``'s interfaces and design patterns.
+
+    .. grid-item-card:: Configuration
+        :text-align: left
+        :link: user_guide/configuration
+        :link-type: doc
+
+        Learn how you can configure ``predictably``.

--- a/docs/source/user_documentation/user_guide/configuration.rst
+++ b/docs/source/user_documentation/user_guide/configuration.rst
@@ -1,0 +1,11 @@
+.. _user_guide_global_config:
+
+=========================
+Configure ``predictably``
+=========================
+
+.. note::
+
+    The user guide is under development. We have created a basic
+    structure and are looking for contributions to develop the user guide
+    further.

--- a/docs/source/user_documentation/user_guide/overview.rst
+++ b/docs/source/user_documentation/user_guide/overview.rst
@@ -1,0 +1,11 @@
+.. _user_guide_overview:
+
+===========================
+Overview of ``predictably``
+===========================
+
+.. note::
+
+    The user guide is under development. We have created a basic
+    structure and are looking for contributions to develop the user guide
+    further.

--- a/docs/source/users.rst
+++ b/docs/source/users.rst
@@ -1,0 +1,62 @@
+.. _user_documentation:
+
+=============
+Documentation
+=============
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   user_documentation/installation
+   user_documentation/tutorials
+   user_documentation/user_guide
+   user_documentation/glossary
+   user_documentation/changelog
+   user_documentation/related_software
+
+
+.. grid:: 1 2 2 2
+    :gutter: 3
+
+    .. grid-item-card:: Installation
+        :text-align: left
+        :link: user_documentation/installation
+        :link-type: doc
+
+        Install ``predictably``.
+
+    .. grid-item-card:: Tutorials
+        :text-align: left
+        :link: user_documentation/tutorials
+        :link-type: doc
+
+        Introductory Tutorials.
+
+    .. grid-item-card:: User Guide
+        :text-align: left
+        :link: user_documentation/user_guide
+        :link-type: doc
+
+        Dig into the details of using ``predictably``.
+
+    .. grid-item-card:: Glossary
+        :text-align: left
+        :link: user_documentation/glossary
+        :link-type: doc
+
+        Understand common terminology.
+
+    .. grid-item-card:: Release Notes
+        :text-align: left
+        :link: user_documentation/changelog
+        :link-type: doc
+
+        See what's new in our latest release.
+
+    .. grid-item-card:: Related Software
+        :text-align: left
+        :link: user_documentation/related_software
+        :link-type: doc
+
+        Explore software related to ``predictably``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ docs = [
     "sphinx-copybutton",
     "sphinx-design",
     "sphinx-issues",
+    "charset-normalizer<3.3",
 ]
 
 test = [


### PR DESCRIPTION
This adds initial documentation that closely follows `skbase` and `sktime`. It can be gradually updated over time to fit the `predictably` packages style.